### PR TITLE
feat(security): allow unauthenticated access to /domicilio/sincronize and disable CSRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2025-10-07
+
+### Changed
+- Security configuration: disabled CSRF globally and permitted all access to /domicilio/sincronize endpoint
+
 ## [1.0.0] - 2025-10-04
 
 ### Added
@@ -41,32 +46,6 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 ### Removed
 - Eliminación completa de dependencias y código Kotlin
 - Remoción de archivos .iml y configuraciones obsoletas
-
-## [Unreleased]
-
-### Added
-- Documentación inicial del proyecto
-- Estructura base del README
-- Configuración de Docker
-- Integración con Swagger UI
-
-### Changed
-- Actualización de dependencias:
-  - Spring Boot a 3.4.4
-  - Kotlin a 2.1.20
-  - MySQL Connector a 9.2.0
-  - Apache POI a 5.4.0
-  - LibrePDF a 2.0.3
-- Mejora en la estructura del proyecto
-- Optimización de la configuración de Maven
-
-### Fixed
-- Corrección de problemas de compatibilidad entre Java y Kotlin
-- Ajustes en la configuración de logging
-
-### Security
-- Actualización de dependencias por seguridad
-- Implementación de validación de entrada
 
 ## [0.0.1-SNAPSHOT] - 2024-03-29
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ mvn spring-boot:run
 
 ## 🔒 Seguridad
 
-La aplicación incluye configuración básica de Spring Security:
+La aplicación incluye configuración de Spring Security:
 - Endpoints de documentación protegidos con autenticación básica
+- Endpoint /domicilio/sincronize permitido sin autenticación
+- CSRF deshabilitado
 - Credenciales configurables via variables de entorno (`app.swagger_user`, `app.swagger_password`)
 
 ## 📚 API Documentation

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>ar.edu</groupId>
 	<artifactId>um.facultad.rest</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 	<name>um.facultad.rest</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>

--- a/src/main/java/um/facultad/rest/configuration/SecurityConfig.java
+++ b/src/main/java/um/facultad/rest/configuration/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 import static org.springframework.security.config.Customizer.withDefaults;
@@ -15,7 +16,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/domicilio/sincronize").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").authenticated()
                         .anyRequest().permitAll()
                 )


### PR DESCRIPTION
## Descripción
Este PR prepara el release v1.1.0 del servicio core de facultades, incluyendo actualizaciones de configuración de seguridad para permitir acceso no autenticado al endpoint de sincronización de domicilios y deshabilitar CSRF globalmente. Resuelve la issue #32 para documentar y liberar los cambios de seguridad.

## Cambios Realizados
- [x] Actualización de `SecurityConfig.java`: deshabilitar CSRF y permitir acceso sin autenticación a `/domicilio/sincronize`.
- [x] Bump de versión en `pom.xml` de 1.0.0 a 1.1.0.
- [x] Actualización de `CHANGELOG.md` con entrada para v1.1.0 y eliminación de sección [Unreleased] obsoleta.
- [x] Actualización de `README.md` para reflejar la nueva configuración de seguridad.

## Impacto Potencial
- [x] Cambios en configuración de seguridad: el endpoint `/domicilio/sincronize` ahora permite acceso sin autenticación, y CSRF está deshabilitado globalmente, lo que puede afectar integraciones que dependan de protección CSRF.
- [x] No se requieren migraciones de base de datos ni cambios en variables de entorno.
- [x] Compatibilidad con APIs REST mejorada al deshabilitar CSRF.

## Verificación
Para verificar los cambios:
1. `git checkout 32-release-v110`
2. `mvn clean install`
3. `mvn test`
4. Verificar que la aplicación inicie correctamente y que el endpoint `/domicilio/sincronize` sea accesible sin autenticación.
5. Confirmar que la documentación en Swagger refleja los cambios de seguridad.

## Notas Adicionales
Los cambios siguen SemVer con un incremento menor debido a la nueva funcionalidad de seguridad. El PR cierra automáticamente la issue #32 al mergearse.