### PR TITLE
build(deps): actualizar dependencias a versiones estables para v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-02-02
+
+### Changed
+- Actualización de Spring Boot de 4.0.0-M3 a 4.0.2
+- Actualización de SpringDoc OpenAPI de 3.0.0-M1 a 3.0.1
+- Actualización de MySQL Connector de 9.4.0 a 9.6.0
+- Actualización de Apache POI de 5.4.1 a 5.5.1
+- Cambio de anotación @AutoConfigureMockMvc para tests (Spring Boot 4.0.2 compatibility)
+
+### Added
+- Dependencia spring-boot-starter-webmvc-test para tests
+
+### Removed
+- Configuración executable del spring-boot-maven-plugin (heredada del parent)
+
 ## [1.1.0] - 2025-10-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Este servicio proporciona la funcionalidad core para la gestión de facultades, 
 ## 🛠️ Tecnologías Utilizadas
 
 - Java 25
-- Spring Boot 4.0.0-M3
-- MySQL 9.4.0
-- Apache POI 5.4.1
+- Spring Boot 4.0.2
+- MySQL 9.6.0
+- Apache POI 5.5.1
 - OpenPDF 3.0.0
-- SpringDoc OpenAPI 3.0.0-M1
+- SpringDoc OpenAPI 3.0.1
 - Spring Security
 - Lombok
 - Docker

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.0-M3</version>
+		<version>4.0.2</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>ar.edu</groupId>
@@ -54,12 +54,12 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>3.0.0-M1</version>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
-			<version>9.4.0</version>
+			<version>9.6.0</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -79,6 +79,11 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
@@ -86,12 +91,12 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>5.4.1</version>
+			<version>5.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>5.4.1</version>
+			<version>5.5.1</version>
 		</dependency>
 		        <dependency>
             <groupId>com.github.librepdf</groupId>
@@ -117,9 +122,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<executable>true</executable>
-				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/um/facultad/rest/controller/CarreraControllerTest.java
+++ b/src/test/java/um/facultad/rest/controller/CarreraControllerTest.java
@@ -2,7 +2,7 @@ package um.facultad.rest.controller;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;

--- a/src/test/java/um/facultad/rest/controller/PersonaControllerTest.java
+++ b/src/test/java/um/facultad/rest/controller/PersonaControllerTest.java
@@ -2,7 +2,7 @@ package um.facultad.rest.controller;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;


### PR DESCRIPTION
Closes #34

## Descripción
Actualización de dependencias a versiones estables para la versión 1.2.0 del proyecto, garantizando compatibilidad y mejorando la estabilidad del sistema.

## Cambios Realizados
- Actualización de Spring Boot de 4.0.0-M3 a 4.0.2
- Actualización de SpringDoc OpenAPI de 3.0.0-M1 a 3.0.1
- Actualización de MySQL Connector de 9.4.0 a 9.6.0
- Actualización de Apache POI de 5.4.1 a 5.5.1
- Adición de dependencia spring-boot-starter-webmvc-test para tests
- Cambio en anotación @AutoConfigureMockMvc en tests (compatibilidad Spring Boot 4.0.2)
- Eliminación de configuración executable del spring-boot-maven-plugin

## Verificación
- Tests existentes pasan
- Compilación exitosa
- Integración con dependencias actualizadas
