### PR TITLE
chore(ci): configurar SonarCloud para análisis de código

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-04-03
+
+### Added
+- Configuración de SonarCloud para análisis de código:
+  - sonar.organization, sonar.projectKey, sonar.host.url, sonar.coverage.jacoco.xmlReportPaths
+
 ## [1.3.1] - 2026-04-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE.md](LICENSE.m
 🟢 Activo - En desarrollo activo
 
 ### Últimas Actualizaciones
+- Configuración de SonarCloud para análisis de código estático
 - Actualización a Spring Boot 4.0.5 y SpringDoc OpenAPI 3.0.2
 - Actualización de OpenPDF a 3.0.3
 - Refactorización de AlumnoExamenController y AlumnoExamenService con inyección por constructor

--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,15 @@
 	</parent>
 	<groupId>ar.edu</groupId>
 	<artifactId>um.facultad.rest</artifactId>
-	<version>1.3.1</version>
+	<version>1.3.2</version>
 	<name>um.facultad.rest</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>25</java.version>
+		<sonar.organization>um-services</sonar.organization>
+		<sonar.projectKey>UM-services_UM.facultad.core-service</sonar.projectKey>
+		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
+		<sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Closes #40

## Descripción
Configuración de SonarCloud para análisis de código estático del proyecto. Esta issue implements la integración con SonarCloud para mejorar la calidad del código mediante análisis automático.

## Cambios Realizados
- **pom.xml**: Actualización de versión a 1.3.2 y adición de propiedades de configuración de SonarCloud (organization, projectKey, host.url, coverage.jacoco.xmlReportPaths)
- **CHANGELOG.md**: Añadida entrada para versión 1.3.2 documentando la configuración de SonarCloud
- **README.md**: Actualización de la sección "Últimas Actualizaciones"

## Verificación
- Verificar que el análisis de SonarCloud se ejecuta correctamente en CI
- Confirmar que los reportes de coverage se generan y suben a SonarCloud