### PR TITLE
release(v1.3.3): update GitHub Actions to latest versions and JDK 25

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 24
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 
@@ -248,7 +248,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs
 
@@ -265,4 +265,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,24 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -54,17 +54,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata for JVM Docker image
         id: meta-jvm
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_IMAGE_NAME }}
           # Add a '-jvm' suffix to tags to differentiate them
@@ -75,10 +75,10 @@ jobs:
             latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push JVM Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           # Point to the new JVM-specific Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-04-03
+
+### Changed
+- Actualización de GitHub Actions en pipeline de documentación:
+  - actions/checkout@v4 → @v6
+  - actions/setup-java@v4 → @v5
+  - actions/upload-pages-artifact@v3 → @v4
+  - actions/deploy-pages@v4 → @v5
+
+### Changed
+- Actualización de GitHub Actions en pipeline Maven:
+  - actions/checkout@v4 → @v6
+  - actions/setup-java@v4 → @v5 (JDK 24 → 25)
+  - actions/cache@v4 → @v5
+  - docker/login-action@v3 → @v4
+  - docker/metadata-action@v5 → @v6
+  - docker/setup-buildx-action@v3 → @v4
+  - docker/build-push-action@v6 → @v7
+
 ## [1.3.2] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,16 +113,15 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE.md](LICENSE.m
 
 🟢 Activo - En desarrollo activo
 
+### Versión Actual
+**1.3.3**
+
 ### Últimas Actualizaciones
+- Actualización de GitHub Actions (v4 → v6) en pipelines de documentación y Maven
+- Actualización de JDK de 24 a 25 en pipeline Maven
+- Actualización de acciones de Docker a últimas versiones
 - Configuración de SonarCloud para análisis de código estático
 - Actualización a Spring Boot 4.0.5 y SpringDoc OpenAPI 3.0.2
-- Actualización de OpenPDF a 3.0.3
-- Refactorización de AlumnoExamenController y AlumnoExamenService con inyección por constructor
-- Migración completa a Java eliminando Kotlin
-- Implementación de Spring Security
-- Adición de tests unitarios
-- Generación automática de documentación via GitHub Actions
-- Refactorización completa de inyección de dependencias
 
 ## 💬 Soporte
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>ar.edu</groupId>
 	<artifactId>um.facultad.rest</artifactId>
-	<version>1.3.2</version>
+	<version>1.3.3</version>
 	<name>um.facultad.rest</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>


### PR DESCRIPTION
Closes #42

## Descripción
Release v1.3.3 con actualización de GitHub Actions a últimas versiones y JDK 25.

## Cambios Realizados
- Actualización de GitHub Actions en pipeline de documentación:
  - actions/checkout@v4 → @v6
  - actions/setup-java@v4 → @v5
  - actions/upload-pages-artifact@v3 → @v4
  - actions/deploy-pages@v4 → @v5
- Actualización de GitHub Actions en pipeline Maven:
  - actions/checkout@v4 → @v6
  - actions/setup-java@v4 → @v5 (JDK 24 → 25)
  - actions/cache@v4 → @v5
  - docker/login-action@v3 → @v4
  - docker/metadata-action@v5 → @v6
  - docker/setup-buildx-action@v3 → @v4
  - docker/build-push-action@v6 → @v7
- Actualización de versión en pom.xml de 1.3.2 a 1.3.3
- Actualización de CHANGELOG.md y README.md

## Verificación
Los pipelines de GitHub Actions se ejecutarán automáticamente al crear el PR.