### PR TITLE
chore(ci): update GitHub Actions to use Node.js 24

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
   pages: write

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-analyze:
     name: Build and Analyze with SonarCloud

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4] - 2026-04-03
+
+### Changed
+- Actualización de configuración de GitHub Actions:
+  - Se agregó la variable de entorno `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` para optar por Node.js 24 y silenciar advertencias de deprecación de Node.js 20.
+
 ## [1.3.3] - 2026-04-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE.md](LICENSE.m
 🟢 Activo - En desarrollo activo
 
 ### Versión Actual
-**1.3.3**
+**1.3.4**
 
 ### Últimas Actualizaciones
+- Actualización de configuración de GitHub Actions: variable `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` para Node.js 24
 - Actualización de GitHub Actions (v4 → v6) en pipelines de documentación y Maven
 - Actualización de JDK de 24 a 25 en pipeline Maven
 - Actualización de acciones de Docker a últimas versiones


### PR DESCRIPTION
Closes #44

## Descripción

Actualización de configuración de GitHub Actions para usar Node.js 24, silenciando las advertencias de deprecación de Node.js 20.

## Cambios Realizados

- `.github/workflows/generate-docs.yml`: Agregada variable de entorno `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
- `.github/workflows/maven.yml`: Agregada variable de entorno `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
- `CHANGELOG.md`: Agregada entrada para versión `[1.3.4]` con fecha `2026-04-03`
- `README.md`: Actualizada versión de `1.3.3` a `1.3.4`

## Verificación

Los cambios se verifican automáticamente al ejecutar los workflows de GitHub Actions en este PR.