### PR TITLE
fix(ci): elimina variable FORCE_JAVASCRIPT_ACTIONS_TO_NODE24

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches: [main]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: write
   pages: write

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build-and-analyze:
     name: Build and Analyze with SonarCloud

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.4] - 2026-04-03
+## [1.3.5] - 2026-04-03
 
-### Changed
-- Actualización de configuración de GitHub Actions:
-  - Se agregó la variable de entorno `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` para optar por Node.js 24 y silenciar advertencias de deprecación de Node.js 20.
+### Fixed
+- Eliminación de la variable `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` para resolver advertencias de acciones "forzadas" a Node.js 24 que aún no lo soportan de forma nativa (como `upload-pages-artifact`).
+- Las acciones que ya soportan Node.js 24 de forma nativa (`checkout@v6`, `setup-java@v5`, etc.) continuarán ejecutándose en Node.js 24 automáticamente.
+
+## [1.3.4] - 2026-04-03
 
 ## [1.3.3] - 2026-04-03
 

--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE.md](LICENSE.m
 🟢 Activo - En desarrollo activo
 
 ### Versión Actual
-**1.3.4**
+**1.3.5**
 
 ### Últimas Actualizaciones
-- Actualización de configuración de GitHub Actions: variable `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` para Node.js 24
+- Resolución de advertencias de GitHub Actions (eliminación de `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`)
 - Actualización de GitHub Actions (v4 → v6) en pipelines de documentación y Maven
 - Actualización de JDK de 24 a 25 en pipeline Maven
 - Actualización de acciones de Docker a últimas versiones

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>ar.edu</groupId>
 	<artifactId>um.facultad.rest</artifactId>
-	<version>1.3.3</version>
+	<version>1.3.5</version>
 	<name>um.facultad.rest</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>


### PR DESCRIPTION
Closes #46

## Descripción

Release v1.3.5 que corrige las advertencias de GitHub Actions relacionadas con Node.js 24.

## Cambios Realizados

- **`.github/workflows/generate-docs.yml`:** Eliminación de la variable de entorno `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
- **`.github/workflows/maven.yml`:** Eliminación de la variable de entorno `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
- **`CHANGELOG.md`:** Actualización a versión `[1.3.5] - 2026-04-03`
- **`README.md`:** Actualización de versión de `1.3.4` a `1.3.5`
- **`pom.xml`:** Actualización de versión de `1.3.3` a `1.3.5`

## Verificación

- [ ] Workflows de GitHub Actions ejecutándose correctamente
- [ ] Versión actualizada en Maven y documentación
