### PR TITLE
fix(model): corrige formato ISO 8601 en entidades y actualiza dependencias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.6] - 2026-06-19
+
+### Changed
+- Actualización de Spring Boot de 4.0.5 a 4.1.0
+- Actualización de MySQL Connector de 9.6.0 a 9.7.0
+- Actualización de SpringDoc OpenAPI de 3.0.2 a 3.0.3
+- Actualización de OpenPDF de 3.0.3 a 3.0.5
+- Actualización de tomcat-embed-core de 11.0.20 a 11.0.22
+
+### Fixed
+- Corrección del formato de fecha ISO 8601: cambio de patrón `Z` a `XX` para incluir separador de dos puntos en el offset de zona horaria en todas las entidades
+
 ## [1.3.5] - 2026-04-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Este servicio proporciona la funcionalidad core para la gestión de facultades, 
 ## 🛠️ Tecnologías Utilizadas
 
 - Java 25
-- Spring Boot 4.0.5
-- MySQL 9.6.0
+- Spring Boot 4.1.0
+- MySQL 9.7.0
 - Apache POI 5.5.1
-- OpenPDF 3.0.3
-- SpringDoc OpenAPI 3.0.2
+- OpenPDF 3.0.5
+- SpringDoc OpenAPI 3.0.3
 - Spring Security
 - Lombok
 - Docker
@@ -29,7 +29,7 @@ Este servicio proporciona la funcionalidad core para la gestión de facultades, 
 - Java 25 o superior
 - Maven 3.8+
 - Docker (opcional)
-- MySQL 5.7+
+- MySQL 8.0+
 
 ## 🚀 Instalación
 
@@ -114,15 +114,11 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE.md](LICENSE.m
 🟢 Activo - En desarrollo activo
 
 ### Versión Actual
-**1.3.5**
+**1.3.6**
 
 ### Últimas Actualizaciones
-- Resolución de advertencias de GitHub Actions (eliminación de `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`)
-- Actualización de GitHub Actions (v4 → v6) en pipelines de documentación y Maven
-- Actualización de JDK de 24 a 25 en pipeline Maven
-- Actualización de acciones de Docker a últimas versiones
-- Configuración de SonarCloud para análisis de código estático
-- Actualización a Spring Boot 4.0.5 y SpringDoc OpenAPI 3.0.2
+- Actualización a Spring Boot 4.1.0, MySQL Connector 9.7.0, SpringDoc OpenAPI 3.0.3, OpenPDF 3.0.5
+- Corrección del formato de fecha ISO 8601 en todas las entidades (patrón `XX` con separador de dos puntos)
 
 ## 💬 Soporte
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.5</version>
+		<version>4.1.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>ar.edu</groupId>
 	<artifactId>um.facultad.rest</artifactId>
-	<version>1.3.5</version>
+	<version>1.3.6</version>
 	<name>um.facultad.rest</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
@@ -58,12 +58,12 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>3.0.2</version>
+			<version>3.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
-			<version>9.6.0</version>
+			<version>9.7.0</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -105,7 +105,7 @@
 		        <dependency>
             <groupId>com.github.librepdf</groupId>
             <artifactId>openpdf</artifactId>
-            <version>3.0.3</version>
+            <version>3.0.5</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -127,7 +127,7 @@
 			<dependency>
 				<groupId>org.apache.tomcat.embed</groupId>
 				<artifactId>tomcat-embed-core</artifactId>
-				<version>11.0.20</version>
+				<version>11.0.22</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/src/main/java/um/facultad/rest/model/BajaEntity.java
+++ b/src/main/java/um/facultad/rest/model/BajaEntity.java
@@ -74,7 +74,7 @@ public class BajaEntity implements Serializable {
 	private String motivo = "";
 
 	@Column(name = "baj_fecha")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 	
 }

--- a/src/main/java/um/facultad/rest/model/DomicilioEntity.java
+++ b/src/main/java/um/facultad/rest/model/DomicilioEntity.java
@@ -40,7 +40,7 @@ public class DomicilioEntity implements Serializable {
 	@Column(name = "clave")
 	private Long domicilioId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha = OffsetDateTime.now();
 
 	private String calle = "";

--- a/src/main/java/um/facultad/rest/model/EstadoEntity.java
+++ b/src/main/java/um/facultad/rest/model/EstadoEntity.java
@@ -54,7 +54,7 @@ public class EstadoEntity implements Serializable {
 	@Column(name = "idestado")
 	private Integer estadoId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 	
 }

--- a/src/main/java/um/facultad/rest/model/InscripcionEntity.java
+++ b/src/main/java/um/facultad/rest/model/InscripcionEntity.java
@@ -52,7 +52,7 @@ public class InscripcionEntity extends Auditable implements Serializable {
 	@Column(name = "ins_id")
 	private Long inscripcionId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 
 	private String chequera = "";

--- a/src/main/java/um/facultad/rest/model/LectivoEntity.java
+++ b/src/main/java/um/facultad/rest/model/LectivoEntity.java
@@ -38,11 +38,11 @@ public class LectivoEntity implements Serializable {
 	private String nombre = "";
 
 	@Column(name = "fecini")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fechaInicio;
 
 	@Column(name = "fecfin")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fechaFinal;
 	
 }

--- a/src/main/java/um/facultad/rest/model/LegajoEntity.java
+++ b/src/main/java/um/facultad/rest/model/LegajoEntity.java
@@ -39,7 +39,7 @@ public class LegajoEntity {
     private Integer lectivoId;
 
     @Column(name = "ale_fecha")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha;
 
     @Column(name = "ale_pla_id")

--- a/src/main/java/um/facultad/rest/model/NacimientoEntity.java
+++ b/src/main/java/um/facultad/rest/model/NacimientoEntity.java
@@ -47,7 +47,7 @@ public class NacimientoEntity implements Serializable {
 	@Column(name = "nci_id")
 	private Long nacimientoId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 	
 	private String lugar;

--- a/src/main/java/um/facultad/rest/model/PlanEntity.java
+++ b/src/main/java/um/facultad/rest/model/PlanEntity.java
@@ -50,7 +50,7 @@ public class PlanEntity implements Serializable {
 
 	private String nombre = "";
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	protected OffsetDateTime fecha;
 
 	@Column(name = "pla_publicar")

--- a/src/main/java/um/facultad/rest/model/PreInscripcionEntity.java
+++ b/src/main/java/um/facultad/rest/model/PreInscripcionEntity.java
@@ -57,7 +57,7 @@ public class PreInscripcionEntity implements Serializable {
 	private Integer turnoId;
 
 	@Column(name = "pin_fecha")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 
 	@Column(name = "pin_chequera")

--- a/src/main/java/um/facultad/rest/model/PreTurnoEntity.java
+++ b/src/main/java/um/facultad/rest/model/PreTurnoEntity.java
@@ -56,11 +56,11 @@ public class PreTurnoEntity implements Serializable {
 	protected String nombre;
 
 	@Column(name = "ptu_inicio")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	protected OffsetDateTime inicio;
 
 	@Column(name = "ptu_fin")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	protected OffsetDateTime fin;
 
 }

--- a/src/main/java/um/facultad/rest/model/RegularidadEntity.java
+++ b/src/main/java/um/facultad/rest/model/RegularidadEntity.java
@@ -60,7 +60,7 @@ public class RegularidadEntity implements Serializable {
 	@Column(name = "idmateria")
 	private String materiaId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 
 	@Column(name = "reg_externa")
@@ -73,7 +73,7 @@ public class RegularidadEntity implements Serializable {
 	private Byte impresa = 0;
 
 	@Column(name = "reg_vencimiento")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento;
 
 }

--- a/src/main/java/um/facultad/rest/model/TituloEntregaEntity.java
+++ b/src/main/java/um/facultad/rest/model/TituloEntregaEntity.java
@@ -59,10 +59,10 @@ public class TituloEntregaEntity implements Serializable {
 	@Column(name = "tit_id")
 	private Long tituloentregaId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime inicio;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime entrega;
 
 	private Long folio;
@@ -87,7 +87,7 @@ public class TituloEntregaEntity implements Serializable {
 	private Integer documentoIdasesor;
 
 	@Column(name = "tit_fecha_ultima")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fechaultima;
 
 	@Column(name = "tit_mat_id_ultima")

--- a/src/main/java/um/facultad/rest/model/view/LegajoKey.java
+++ b/src/main/java/um/facultad/rest/model/view/LegajoKey.java
@@ -58,7 +58,7 @@ public class LegajoKey implements Serializable {
 	private Integer lectivoId;
 
 	@Column(name = "ale_fecha")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 
 	@Column(name = "ale_pla_id")


### PR DESCRIPTION
Closes #48

## Descripción

Release **v1.3.6** que incluye actualización de dependencias y corrección en el formato de fechas ISO 8601. Se cambia el patrón `Z` a `XX` en todas las entidades para incluir el separador de dos puntos en el offset de zona horaria, cumpliendo con el estándar ISO 8601.

## Cambios Realizados

### Dependencias Actualizadas

| Dependencia | Versión Anterior | Versión Nueva |
|---|---|---|
| Spring Boot | 4.0.5 | 4.1.0 |
| MySQL Connector | 9.6.0 | 9.7.0 |
| SpringDoc OpenAPI | 3.0.2 | 3.0.3 |
| OpenPDF | 3.0.3 | 3.0.5 |
| tomcat-embed-core | 11.0.20 | 11.0.22 |

### Correcciones

- **Formato ISO 8601:** Cambio de patrón `Z` → `XX` en 13 entidades para incluir el separador `:` en el offset de zona horaria (ej: `+00:00` en lugar de `+0000`).

### Documentación

- Actualización de versiones en `README.md`
- Actualización del requisito de MySQL de 5.7+ a 8.0+
- Registro de cambios en `CHANGELOG.md`

## Archivos Modificados

- `pom.xml`
- `README.md`
- `CHANGELOG.md`
- `src/main/java/um/facultad/rest/model/BajaEntity.java`
- `src/main/java/um/facultad/rest/model/DomicilioEntity.java`
- `src/main/java/um/facultad/rest/model/EstadoEntity.java`
- `src/main/java/um/facultad/rest/model/InscripcionEntity.java`
- `src/main/java/um/facultad/rest/model/LectivoEntity.java`
- `src/main/java/um/facultad/rest/model/LegajoEntity.java`
- `src/main/java/um/facultad/rest/model/NacimientoEntity.java`
- `src/main/java/um/facultad/rest/model/PlanEntity.java`
- `src/main/java/um/facultad/rest/model/PreInscripcionEntity.java`
- `src/main/java/um/facultad/rest/model/PreTurnoEntity.java`
- `src/main/java/um/facultad/rest/model/RegularidadEntity.java`
- `src/main/java/um/facultad/rest/model/TituloEntregaEntity.java`
- `src/main/java/um/facultad/rest/model/view/LegajoKey.java`

## Verificación

- [ ] Compilación exitosa con `mvn clean compile`
- [ ] Pruebas unitarias pasan con `mvn test`
- [ ] Formato ISO 8601 validado en respuestas JSON
