### PR TITLE
refactor(di): migra de @Autowired a inyección por constructor en 47 clases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-07-31
+
+### Changed
+- Refactorización de inyección de dependencias: migración completa de `@Autowired` (inyección por campo) a inyección por constructor con `@RequiredArgsConstructor` en 47 controladores y servicios
+- `InscripcionController`: reemplazo de `new ResponseEntity<>(..., HttpStatus.OK)` por `ResponseEntity.ok()` y eliminación de la causa redundante en `ResponseStatusException`
+- `MatriculacionContextRepositoryImpl`: migrado a inyección por constructor, trasladando `@Qualifier("personasPersonaMapper")` al campo
+- Limpieza de código en `MailService` y `FormularioController`: eliminación de constructores explícitos redundantes
+
 ## [1.6.0] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,14 +131,12 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE.md](LICENSE.m
 🟢 Activo - En desarrollo activo
 
 ### Versión Actual
-**1.6.0**
+**1.6.1**
 
 ### Últimas Actualizaciones
-- Nuevo bounded context `personas` con módulos hexagonales de persona y domicilio (controladores REST, servicios, casos de uso, adaptadores JPA y DTOs)
-- Nuevo módulo hexagonal `inscripcionPago` con `InscripcionPagoService`, casos de uso y adaptador JPA
-- El domain model `Persona` incorpora los campos `sexo`, `profesionId` y `mascara`
-- `InscripcionFullDto` y `PendienteInfo` migrados a domain models (ya no usan entidades JPA)
-- Migración de los servicios, controladores y repositorios legacy de persona, domicilio e inscripción-pago a la arquitectura hexagonal
+- Refactorización de la inyección de dependencias: migración de `@Autowired` a inyección por constructor (`@RequiredArgsConstructor`) en 47 controladores y servicios
+- Limpieza de código en `InscripcionController` (`ResponseEntity.ok()`, `ResponseStatusException` sin causa redundante)
+- `MatriculacionContextRepositoryImpl` migrado a inyección por constructor con `@Qualifier("personasPersonaMapper")` a nivel de campo
 
 ## 💬 Soporte
 

--- a/docs/diagrams/despliegue-infraestructura.mmd
+++ b/docs/diagrams/despliegue-infraestructura.mmd
@@ -1,16 +1,26 @@
 graph TB
-    subgraph "GitHub Actions"
-        A[CI/CD Pipeline]
+    subgraph GH ["GitHub Actions"]
+        A["CI/CD Pipeline"]
     end
 
-    subgraph "Docker Container"
-        B[Spring Boot App]
-        B --> C[MySQL]
-        B --> D[External APIs]
+    subgraph DC ["Docker Container"]
+        B["Spring Boot App"]
     end
 
-    A --> E[Build & Test]
-    E --> F[Deploy to Prod]
+    subgraph EX ["Externos"]
+        C["MySQL Database"]
+        D["External APIs"]
+    end
 
+    A --> E["Build & Test"]
+    E --> F["Deploy to Prod"]
+    F --> B
+    B --> C
+    B --> D
+
+    style A fill:#e1f5fe
+    style E fill:#e1f5fe
+    style F fill:#e1f5fe
     style B fill:#e8f5e8
     style C fill:#fff3e0
+    style D fill:#fff3e0

--- a/docs/diagrams/flujo-inscripcion.mmd
+++ b/docs/diagrams/flujo-inscripcion.mmd
@@ -14,7 +14,7 @@ sequenceDiagram
     IPS-->>UC: inscripcionPago
     UC->>PS: findByPersonaIdAndDocumentoId(personaIdPagador, documentoId)
     PS-->>UC: personaPago
-    UC->>DS: findByPersonaIdAndDocumentoId(personaId, documentoId)
+    UC->>DS: findByPersonaIdAndDocumentoId(personaPago.personaId, personaPago.documentoId)
     DS-->>UC: domicilioPago
     UC-->>C: InscripcionFullDto
     C-->>U: 200 OK (InscripcionFullDto)

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>ar.edu</groupId>
 	<artifactId>um.facultad.rest</artifactId>
-	<version>1.6.0</version>
+	<version>1.6.1</version>
 	<name>um.facultad.rest</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>

--- a/src/main/java/um/facultad/rest/controller/BajaController.java
+++ b/src/main/java/um/facultad/rest/controller/BajaController.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.controller;
 
+import lombok.RequiredArgsConstructor;
 import java.math.BigDecimal;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,10 +26,10 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequestMapping("/baja")
 @Slf4j
+@RequiredArgsConstructor
 public class BajaController {
 
-	@Autowired
-	private BajaService service;
+	private final BajaService service;
 
 	@GetMapping("/unique/{facultadId}/{personaId}/{documentoId}/{lectivoId}")
 	public ResponseEntity<BajaEntity> findByUnique(@PathVariable Integer facultadId, @PathVariable BigDecimal personaId,

--- a/src/main/java/um/facultad/rest/controller/LectivoController.java
+++ b/src/main/java/um/facultad/rest/controller/LectivoController.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.controller;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,10 +21,10 @@ import um.facultad.rest.service.LectivoService;
  */
 @RestController
 @RequestMapping("/lectivo")
+@RequiredArgsConstructor
 public class LectivoController {
 
-	@Autowired
-	private LectivoService service;
+	private final LectivoService service;
 
 	@GetMapping("/")
 	public ResponseEntity<List<LectivoEntity>> findAll() {

--- a/src/main/java/um/facultad/rest/controller/LocalidadController.java
+++ b/src/main/java/um/facultad/rest/controller/LocalidadController.java
@@ -3,7 +3,7 @@
  */
 package um.facultad.rest.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,10 +20,10 @@ import um.facultad.rest.service.LocalidadService;
  */
 @RestController
 @RequestMapping("/localidad")
+@RequiredArgsConstructor
 public class LocalidadController {
 	
-	@Autowired
-	private LocalidadService service;
+	private final LocalidadService service;
 
 	@GetMapping("/unique/{facultadId}/{provinciaId}/{localidadId}")
 	public ResponseEntity<LocalidadEntity> findByUnique(@PathVariable Integer facultadId, @PathVariable Integer provinciaId,

--- a/src/main/java/um/facultad/rest/controller/PreInscripcionController.java
+++ b/src/main/java/um/facultad/rest/controller/PreInscripcionController.java
@@ -3,10 +3,10 @@
  */
 package um.facultad.rest.controller;
 
+import lombok.RequiredArgsConstructor;
 import java.math.BigDecimal;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,10 +23,10 @@ import um.facultad.rest.service.PreInscripcionService;
  */
 @RestController
 @RequestMapping("/preinscripcion")
+@RequiredArgsConstructor
 public class PreInscripcionController {
 
-	@Autowired
-	private PreInscripcionService service;
+	private final PreInscripcionService service;
 
 	@GetMapping("/lectivo/{facultadId}/{lectivoId}")
 	public ResponseEntity<List<PreInscripcionEntity>> findAllByLectivo(@PathVariable Integer facultadId,

--- a/src/main/java/um/facultad/rest/controller/PreTurnoController.java
+++ b/src/main/java/um/facultad/rest/controller/PreTurnoController.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.controller;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,10 +22,10 @@ import um.facultad.rest.service.PreTurnoService;
  */
 @RestController
 @RequestMapping("/preturno")
+@RequiredArgsConstructor
 public class PreTurnoController {
 
-	@Autowired
-	private PreTurnoService service;
+	private final PreTurnoService service;
 
 	@GetMapping("/lectivo/{facultadId}/{lectivoId}")
 	public ResponseEntity<List<PreTurnoEntity>> findAllByLectivo(@PathVariable Integer facultadId,

--- a/src/main/java/um/facultad/rest/controller/ProvinciaController.java
+++ b/src/main/java/um/facultad/rest/controller/ProvinciaController.java
@@ -3,7 +3,7 @@
  */
 package um.facultad.rest.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,10 +20,10 @@ import um.facultad.rest.service.ProvinciaService;
  */
 @RestController
 @RequestMapping("/provincia")
+@RequiredArgsConstructor
 public class ProvinciaController {
 	
-	@Autowired
-	private ProvinciaService service;
+	private final ProvinciaService service;
 
 	@GetMapping("/unique/{facultadId}/{provinciaId}")
 	public ResponseEntity<ProvinciaEntity> findByUnique(@PathVariable Integer facultadId, @PathVariable Integer provinciaId) {

--- a/src/main/java/um/facultad/rest/controller/SetupApiController.java
+++ b/src/main/java/um/facultad/rest/controller/SetupApiController.java
@@ -3,7 +3,7 @@
  */
 package um.facultad.rest.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,10 +19,10 @@ import um.facultad.rest.service.SetupApiService;
  */
 @RestController
 @RequestMapping("/setupapi")
+@RequiredArgsConstructor
 public class SetupApiController {
 	
-	@Autowired
-	private SetupApiService service;
+	private final SetupApiService service;
 	
 	@GetMapping("/last")
 	public ResponseEntity<SetupApiEntity> findLast() {

--- a/src/main/java/um/facultad/rest/controller/TituloEntregaController.java
+++ b/src/main/java/um/facultad/rest/controller/TituloEntregaController.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.controller;
 
+import lombok.RequiredArgsConstructor;
 import java.math.BigDecimal;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,10 +22,10 @@ import um.facultad.rest.service.TituloEntregaService;
  */
 @RestController
 @RequestMapping("/tituloentrega")
+@RequiredArgsConstructor
 public class TituloEntregaController {
 
-	@Autowired
-	private TituloEntregaService service;
+	private final TituloEntregaService service;
 
 	@GetMapping("/unique/{personaId}/{documentoId}/{facultadId}/{planId}/{carreraId}")
 	public ResponseEntity<TituloEntregaEntity> findByUnique(@PathVariable BigDecimal personaId,

--- a/src/main/java/um/facultad/rest/controller/dto/PendienteInfoController.java
+++ b/src/main/java/um/facultad/rest/controller/dto/PendienteInfoController.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.controller.dto;
 
+import lombok.RequiredArgsConstructor;
 import java.math.BigDecimal;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,10 +22,10 @@ import um.facultad.rest.service.dto.PendienteInfoService;
  */
 @RestController
 @RequestMapping("/pendienteinfo")
+@RequiredArgsConstructor
 public class PendienteInfoController {
 
-	@Autowired
-	private PendienteInfoService service;
+	private final PendienteInfoService service;
 
 	@GetMapping("/info/{facultadId}/{lectivoId}/{geograficaId}/{personaId}/{documentoId}")
 	public ResponseEntity<PendienteInfo> findByAlumno(@PathVariable Integer facultadId, @PathVariable Integer lectivoId,

--- a/src/main/java/um/facultad/rest/controller/facade/AutoMatriculaController.java
+++ b/src/main/java/um/facultad/rest/controller/facade/AutoMatriculaController.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.controller.facade;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,10 +22,10 @@ import um.facultad.rest.service.facade.AutoMatriculaService;
  */
 @RestController
 @RequestMapping("/automatricula")
+@RequiredArgsConstructor
 public class AutoMatriculaController {
 
-	@Autowired
-	private AutoMatriculaService service;
+	private final AutoMatriculaService service;
 
 	@GetMapping("/pre/{facultadId}/{lectivoId}/{geograficaId}/{turnoId}")
 	public ResponseEntity<List<Inscripcion>> auto_matricula_pre(@PathVariable Integer facultadId,

--- a/src/main/java/um/facultad/rest/controller/facade/FormularioController.java
+++ b/src/main/java/um/facultad/rest/controller/facade/FormularioController.java
@@ -3,6 +3,8 @@
  */
 package um.facultad.rest.controller.facade;
 
+import lombok.RequiredArgsConstructor;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -31,15 +33,11 @@ import jakarta.mail.MessagingException;
  */
 @RestController
 @RequestMapping("/formularios")
+@RequiredArgsConstructor
 public class FormularioController {
 
 	private final MatriculaToPdfService matriculaToPdfService;
 	private final MailService mailing;
-
-	public FormularioController(MatriculaToPdfService matriculaToPdfService, MailService mailing) {
-		this.matriculaToPdfService = matriculaToPdfService;
-		this.mailing = mailing;
-	}
 
 	@GetMapping("/matricula/{personaId}/{documentoId}/{facultadId}/{lectivoId}")
 	public ResponseEntity<Resource> generateMatricula(@PathVariable BigDecimal personaId, @PathVariable Integer documentoId,

--- a/src/main/java/um/facultad/rest/controller/facade/NotificacionController.java
+++ b/src/main/java/um/facultad/rest/controller/facade/NotificacionController.java
@@ -3,10 +3,10 @@
  */
 package um.facultad.rest.controller.facade;
 
+import lombok.RequiredArgsConstructor;
 import java.math.BigDecimal;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,10 +25,10 @@ import jakarta.mail.MessagingException;
  */
 @RestController
 @RequestMapping("/notificacion")
+@RequiredArgsConstructor
 public class NotificacionController {
 
-	@Autowired
-	private MailService service;
+	private final MailService service;
 
 	/**
 	 * Este endpoint envía una notificacion por mail en caso que el alumno rinda

--- a/src/main/java/um/facultad/rest/controller/facade/SheetController.java
+++ b/src/main/java/um/facultad/rest/controller/facade/SheetController.java
@@ -3,11 +3,11 @@
  */
 package um.facultad.rest.controller.facade;
 
+import lombok.RequiredArgsConstructor;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -26,10 +26,10 @@ import um.facultad.rest.service.facade.SheetService;
  */
 @RestController
 @RequestMapping("/sheet")
+@RequiredArgsConstructor
 public class SheetController {
 
-	@Autowired
-	private SheetService service;
+	private final SheetService service;
 
 	@GetMapping("/matriculacurso/{facultadId}/{lectivoId}/{geograficaId}/{curso}")
 	public ResponseEntity<Resource> generateCargos(@PathVariable Integer facultadId, @PathVariable Integer lectivoId,

--- a/src/main/java/um/facultad/rest/controller/view/InscriptoCursoController.java
+++ b/src/main/java/um/facultad/rest/controller/view/InscriptoCursoController.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.controller.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,10 +22,10 @@ import um.facultad.rest.service.view.InscriptoCursoService;
  */
 @RestController
 @RequestMapping("/inscriptocurso")
+@RequiredArgsConstructor
 public class InscriptoCursoController {
 
-	@Autowired
-	private InscriptoCursoService service;
+	private final InscriptoCursoService service;
 
 	@GetMapping("/lectivo/{facultadId}/{lectivoId}/{geograficaId}")
 	public ResponseEntity<List<InscriptoCurso>> findAllByLectivo(@PathVariable Integer facultadId,

--- a/src/main/java/um/facultad/rest/controller/view/LegajoKeyController.java
+++ b/src/main/java/um/facultad/rest/controller/view/LegajoKeyController.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.controller.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,10 +23,10 @@ import um.facultad.rest.service.view.LegajoKeyService;
  */
 @RestController
 @RequestMapping("/legajokey")
+@RequiredArgsConstructor
 public class LegajoKeyController {
 
-	@Autowired
-	private LegajoKeyService service;
+	private final LegajoKeyService service;
 
 	@PostMapping("/unifieds/{facultadId}")
 	public ResponseEntity<List<LegajoKey>> findAllByFacultadAndPersonaKeys(@PathVariable Integer facultadId,

--- a/src/main/java/um/facultad/rest/controller/view/PersonaKeyController.java
+++ b/src/main/java/um/facultad/rest/controller/view/PersonaKeyController.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.controller.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,10 +22,10 @@ import um.facultad.rest.service.view.PersonaKeyService;
  */
 @RestController
 @RequestMapping("/personakey")
+@RequiredArgsConstructor
 public class PersonaKeyController {
 
-	@Autowired
-	private PersonaKeyService service;
+	private final PersonaKeyService service;
 
 	@PostMapping("/unifieds")
 	public ResponseEntity<List<PersonaKey>> findAllByUnifieds(@RequestBody List<String> unifieds) {

--- a/src/main/java/um/facultad/rest/controller/view/PreunivCarreraController.java
+++ b/src/main/java/um/facultad/rest/controller/view/PreunivCarreraController.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.controller.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,10 +22,10 @@ import um.facultad.rest.service.view.PreunivCarreraService;
  */
 @RestController
 @RequestMapping("/preunivcarrera")
+@RequiredArgsConstructor
 public class PreunivCarreraController {
 
-	@Autowired
-	private PreunivCarreraService service;
+	private final PreunivCarreraService service;
 
 	@GetMapping("/lectivo/{facultadId}/{lectivoId}")
 	public ResponseEntity<List<PreunivCarrera>> findAllByLectivo(@PathVariable Integer facultadId,

--- a/src/main/java/um/facultad/rest/controller/view/PreunivMatricResumenController.java
+++ b/src/main/java/um/facultad/rest/controller/view/PreunivMatricResumenController.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.controller.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,10 +22,10 @@ import um.facultad.rest.service.view.PreunivMatricResumenService;
  */
 @RestController
 @RequestMapping("/preunivmatricresumen")
+@RequiredArgsConstructor
 public class PreunivMatricResumenController {
 
-	@Autowired
-	private PreunivMatricResumenService service;
+	private final PreunivMatricResumenService service;
 
 	@GetMapping("/lectivo/{facultadId}/{lectivoId}")
 	public ResponseEntity<List<PreunivMatricResumen>> findAllByLectivo(@PathVariable Integer facultadId,

--- a/src/main/java/um/facultad/rest/controller/view/PreunivResumenController.java
+++ b/src/main/java/um/facultad/rest/controller/view/PreunivResumenController.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.controller.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,10 +22,10 @@ import um.facultad.rest.service.view.PreunivResumenService;
  */
 @RestController
 @RequestMapping("/preunivresumen")
+@RequiredArgsConstructor
 public class PreunivResumenController {
 
-	@Autowired
-	private PreunivResumenService service;
+	private final PreunivResumenService service;
 
 	@GetMapping("/lectivo/{facultadId}/{lectivoId}")
 	public ResponseEntity<List<PreunivResumen>> findAllByLectivo(@PathVariable Integer facultadId,

--- a/src/main/java/um/facultad/rest/hexagonal/inscripciones/inscripcion/infrastructure/web/controller/InscripcionController.java
+++ b/src/main/java/um/facultad/rest/hexagonal/inscripciones/inscripcion/infrastructure/web/controller/InscripcionController.java
@@ -1,5 +1,6 @@
 package um.facultad.rest.hexagonal.inscripciones.inscripcion.infrastructure.web.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,15 +16,11 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/inscripcion")
+@RequiredArgsConstructor
 public class InscripcionController {
 
     private final InscripcionService service;
     private final InscripcionDtoMapper inscripcionDtoMapper;
-
-    public InscripcionController(InscripcionService service, InscripcionDtoMapper inscripcionDtoMapper) {
-        this.service = service;
-        this.inscripcionDtoMapper = inscripcionDtoMapper;
-    }
 
     @GetMapping("/lectivo/{facultadId}/{lectivoId}")
     public ResponseEntity<List<InscripcionResponse>> findAllByLectivo(@PathVariable Integer facultadId,
@@ -32,7 +29,7 @@ public class InscripcionController {
                 .stream()
                 .map(inscripcionDtoMapper::toResponse)
                 .toList();
-        return new ResponseEntity<>(inscriptos, HttpStatus.OK);
+        return ResponseEntity.ok(inscriptos);
     }
 
     @GetMapping("/curso/{facultadId}/{lectivoId}/{geograficaId}/{curso}")
@@ -44,7 +41,7 @@ public class InscripcionController {
                 .stream()
                 .map(inscripcionDtoMapper::toResponse)
                 .toList();
-        return new ResponseEntity<>(inscriptos, HttpStatus.OK);
+        return ResponseEntity.ok(inscriptos);
     }
 
     @GetMapping("/cursosinprovisoria/{facultadId}/{lectivoId}/{geograficaId}/{curso}")
@@ -56,7 +53,7 @@ public class InscripcionController {
                 .stream()
                 .map(inscripcionDtoMapper::toResponse)
                 .toList();
-        return new ResponseEntity<>(inscriptos, HttpStatus.OK);
+        return ResponseEntity.ok(inscriptos);
     }
 
     @GetMapping("/unique/{facultadId}/{personaId}/{documentoId}/{lectivoId}")
@@ -66,9 +63,9 @@ public class InscripcionController {
                                                              @PathVariable Integer lectivoId) {
         try {
             var inscripcion = service.findByUnique(facultadId, personaId, documentoId, lectivoId);
-            return new ResponseEntity<>(inscripcionDtoMapper.toResponse(inscripcion), HttpStatus.OK);
+            return ResponseEntity.ok(inscripcionDtoMapper.toResponse(inscripcion));
         } catch (InscripcionException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         }
     }
 

--- a/src/main/java/um/facultad/rest/hexagonal/inscripciones/matriculacion/infrastructure/persistence/MatriculacionContextRepositoryImpl.java
+++ b/src/main/java/um/facultad/rest/hexagonal/inscripciones/matriculacion/infrastructure/persistence/MatriculacionContextRepositoryImpl.java
@@ -1,6 +1,6 @@
 package um.facultad.rest.hexagonal.inscripciones.matriculacion.infrastructure.persistence;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import um.facultad.rest.hexagonal.inscripciones.inscripcion.application.exception.InscripcionException;
@@ -18,20 +18,14 @@ import um.facultad.rest.hexagonal.personas.persona.infrastructure.persistence.re
 import java.math.BigDecimal;
 
 @Component
+@RequiredArgsConstructor
 public class MatriculacionContextRepositoryImpl implements MatriculacionContextRepository {
 
     private final JpaPersonaRepository personaRepository;
+    @Qualifier("personasPersonaMapper")
     private final PersonaMapper personaMapper;
     private final JpaInscripcionRepository inscripcionRepository;
     private final InscripcionMapper inscripcionMapper;
-
-    @Autowired
-    public MatriculacionContextRepositoryImpl(JpaPersonaRepository personaRepository, @Qualifier("personasPersonaMapper") PersonaMapper personaMapper, JpaInscripcionRepository inscripcionRepository, InscripcionMapper inscripcionMapper) {
-        this.personaRepository = personaRepository;
-        this.personaMapper = personaMapper;
-        this.inscripcionRepository = inscripcionRepository;
-        this.inscripcionMapper = inscripcionMapper;
-    }
 
     @Override
     public Persona findPersonaByPersonaIdAndDocumentoId(BigDecimal personaId, Integer documentoId) {

--- a/src/main/java/um/facultad/rest/service/BajaService.java
+++ b/src/main/java/um/facultad/rest/service/BajaService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service;
 
+import lombok.RequiredArgsConstructor;
 import java.math.BigDecimal;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.exception.BajaException;
@@ -17,10 +17,10 @@ import um.facultad.rest.repository.BajaRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class BajaService {
 
-	@Autowired
-	private BajaRepository repository;
+	private final BajaRepository repository;
 
 	public BajaEntity findByUnique(Integer facultadId, BigDecimal personaId, Integer documentoId, Integer lectivoId) {
 		return repository.findByFacultadIdAndPersonaIdAndDocumentoIdAndLectivoId(facultadId, personaId, documentoId,

--- a/src/main/java/um/facultad/rest/service/DivisionService.java
+++ b/src/main/java/um/facultad/rest/service/DivisionService.java
@@ -3,7 +3,7 @@
  */
 package um.facultad.rest.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.exception.DivisionException;
@@ -15,10 +15,10 @@ import um.facultad.rest.repository.DivisionRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class DivisionService {
 
-	@Autowired
-	private DivisionRepository repository;
+	private final DivisionRepository repository;
 
 	public DivisionEntity findByUnique(Integer facultadId, Integer divisionId) {
 		return repository.findByFacultadIdAndDivisionId(facultadId, divisionId)

--- a/src/main/java/um/facultad/rest/service/DocumentoService.java
+++ b/src/main/java/um/facultad/rest/service/DocumentoService.java
@@ -3,7 +3,7 @@
  */
 package um.facultad.rest.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.exception.DocumentoException;
@@ -15,10 +15,10 @@ import um.facultad.rest.repository.DocumentoRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class DocumentoService {
 
-	@Autowired
-	private DocumentoRepository repository;
+	private final DocumentoRepository repository;
 
 	public DocumentoEntity findByDocumentoId(Integer documentoId) {
 		return repository.findByDocumentoId(documentoId).orElseThrow(() -> new DocumentoException(documentoId));

--- a/src/main/java/um/facultad/rest/service/EstadoAlumnoService.java
+++ b/src/main/java/um/facultad/rest/service/EstadoAlumnoService.java
@@ -3,7 +3,7 @@
  */
 package um.facultad.rest.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.exception.EstadoAlumnoException;
@@ -15,10 +15,10 @@ import um.facultad.rest.repository.EstadoAlumnoRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class EstadoAlumnoService {
 
-	@Autowired
-	private EstadoAlumnoRepository repository;
+	private final EstadoAlumnoRepository repository;
 
 	public EstadoAlumnoEntity findByEstadoId(Integer estadoId) {
 		return repository.findByEstadoId(estadoId).orElseThrow(() -> new EstadoAlumnoException(estadoId));

--- a/src/main/java/um/facultad/rest/service/EstadoService.java
+++ b/src/main/java/um/facultad/rest/service/EstadoService.java
@@ -3,10 +3,10 @@
  */
 package um.facultad.rest.service;
 
+import lombok.RequiredArgsConstructor;
 import java.math.BigDecimal;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.model.EstadoEntity;
@@ -17,10 +17,10 @@ import um.facultad.rest.repository.EstadoRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class EstadoService {
 
-	@Autowired
-	private EstadoRepository repository;
+	private final EstadoRepository repository;
 
 	public List<EstadoEntity> findAllByPersonaIdInAndFacultadId(List<BigDecimal> numeros, Integer facultadId) {
 		return repository.findAllByPersonaIdInAndFacultadId(numeros, facultadId);

--- a/src/main/java/um/facultad/rest/service/FacultadService.java
+++ b/src/main/java/um/facultad/rest/service/FacultadService.java
@@ -3,7 +3,7 @@
  */
 package um.facultad.rest.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.exception.FacultadException;
@@ -15,10 +15,10 @@ import um.facultad.rest.repository.FacultadRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class FacultadService {
 
-	@Autowired
-	private FacultadRepository repository;
+	private final FacultadRepository repository;
 
 	public FacultadEntity findByFacultadId(Integer facultadId) {
 		return repository.findByFacultadId(facultadId).orElseThrow(() -> new FacultadException(facultadId));

--- a/src/main/java/um/facultad/rest/service/GeograficaService.java
+++ b/src/main/java/um/facultad/rest/service/GeograficaService.java
@@ -3,7 +3,7 @@
  */
 package um.facultad.rest.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.exception.GeograficaException;
@@ -15,10 +15,10 @@ import um.facultad.rest.repository.GeograficaRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class GeograficaService {
 
-	@Autowired
-	private GeograficaRepository repository;
+	private final GeograficaRepository repository;
 
 	public GeograficaEntity findByGeograficaId(Integer geograficaId) {
 		return repository.findByGeograficaId(geograficaId).orElseThrow(() -> new GeograficaException(geograficaId));

--- a/src/main/java/um/facultad/rest/service/LectivoService.java
+++ b/src/main/java/um/facultad/rest/service/LectivoService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -18,10 +18,10 @@ import um.facultad.rest.repository.LectivoRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class LectivoService {
 
-	@Autowired
-	private LectivoRepository repository;
+	private final LectivoRepository repository;
 
 	public List<LectivoEntity> findAll() {
 		return repository.findAll(Sort.by("lectivoId").ascending());

--- a/src/main/java/um/facultad/rest/service/LocalidadService.java
+++ b/src/main/java/um/facultad/rest/service/LocalidadService.java
@@ -3,7 +3,7 @@
  */
 package um.facultad.rest.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.exception.LocalidadException;
@@ -15,10 +15,10 @@ import um.facultad.rest.repository.LocalidadRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class LocalidadService {
 
-	@Autowired
-	private LocalidadRepository repository;
+	private final LocalidadRepository repository;
 
 	public LocalidadEntity findByUnique(Integer facultadId, Integer provinciaId, Integer localidadId) {
 		return repository.findByFacultadIdAndProvinciaIdAndLocalidadId(facultadId, provinciaId, localidadId)

--- a/src/main/java/um/facultad/rest/service/MateriaCarreraService.java
+++ b/src/main/java/um/facultad/rest/service/MateriaCarreraService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.model.MateriaCarreraEntity;
@@ -16,10 +16,10 @@ import um.facultad.rest.repository.MateriaCarreraRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class MateriaCarreraService {
 
-	@Autowired
-	private MateriaCarreraRepository repository;
+	private final MateriaCarreraRepository repository;
 
 	public List<MateriaCarreraEntity> findAllByCarrera(Integer facultadId, Integer planId, Integer carreraId) {
 		return repository.findAllByFacultadIdAndPlanIdAndCarreraId(facultadId, planId, carreraId);

--- a/src/main/java/um/facultad/rest/service/MateriaCursoService.java
+++ b/src/main/java/um/facultad/rest/service/MateriaCursoService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.model.MateriaCursoEntity;
@@ -16,10 +16,10 @@ import um.facultad.rest.repository.MateriaCursoRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class MateriaCursoService {
 
-	@Autowired
-	private MateriaCursoRepository repository;
+	private final MateriaCursoRepository repository;
 
 	public List<MateriaCursoEntity> findAllByCurso(Integer facultadId, Integer planId, Integer carreraId, Integer curso) {
 		return repository.findAllByFacultadIdAndPlanIdAndCarreraIdAndCurso(facultadId, planId, carreraId, curso);

--- a/src/main/java/um/facultad/rest/service/NacimientoService.java
+++ b/src/main/java/um/facultad/rest/service/NacimientoService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service;
 
+import lombok.RequiredArgsConstructor;
 import java.math.BigDecimal;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.exception.NacimientoException;
@@ -17,10 +17,10 @@ import um.facultad.rest.repository.NacimientoRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class NacimientoService {
 
-	@Autowired
-	private NacimientoRepository repository;
+	private final NacimientoRepository repository;
 
 	public NacimientoEntity findByUnique(BigDecimal personaId, Integer documentoId) {
 		return repository.findByPersonaIdAndDocumentoId(personaId, documentoId)

--- a/src/main/java/um/facultad/rest/service/PreInscripcionService.java
+++ b/src/main/java/um/facultad/rest/service/PreInscripcionService.java
@@ -3,10 +3,10 @@
  */
 package um.facultad.rest.service;
 
+import lombok.RequiredArgsConstructor;
 import java.math.BigDecimal;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.exception.PreInscripcionException;
@@ -18,10 +18,10 @@ import um.facultad.rest.repository.PreInscripcionRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class PreInscripcionService {
 
-	@Autowired
-	private PreInscripcionRepository repository;
+	private final PreInscripcionRepository repository;
 
 	public List<PreInscripcionEntity> findAllByLectivo(Integer facultadId, Integer lectivoId) {
 		return repository.findAllByFacultadIdAndLectivoId(facultadId, lectivoId);

--- a/src/main/java/um/facultad/rest/service/PreTurnoService.java
+++ b/src/main/java/um/facultad/rest/service/PreTurnoService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.model.PreTurnoEntity;
@@ -16,10 +16,10 @@ import um.facultad.rest.repository.PreTurnoRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class PreTurnoService {
 
-	@Autowired
-	private PreTurnoRepository repository;
+	private final PreTurnoRepository repository;
 
 	public List<PreTurnoEntity> findAllByLectivo(Integer facultadId, Integer lectivoId) {
 		return repository.findAllByFacultadIdAndLectivoId(facultadId, lectivoId);

--- a/src/main/java/um/facultad/rest/service/ProvinciaService.java
+++ b/src/main/java/um/facultad/rest/service/ProvinciaService.java
@@ -3,7 +3,7 @@
  */
 package um.facultad.rest.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.exception.ProvinciaException;
@@ -15,9 +15,9 @@ import um.facultad.rest.repository.ProvinciaRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class ProvinciaService {
-	@Autowired
-	private ProvinciaRepository repository;
+	private final ProvinciaRepository repository;
 
 	public ProvinciaEntity findByUnique(Integer facultadId, Integer provinciaId) {
 		return repository.findByFacultadIdAndProvinciaId(facultadId, provinciaId)

--- a/src/main/java/um/facultad/rest/service/RegularidadService.java
+++ b/src/main/java/um/facultad/rest/service/RegularidadService.java
@@ -3,10 +3,10 @@
  */
 package um.facultad.rest.service;
 
+import lombok.RequiredArgsConstructor;
 import java.math.BigDecimal;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.model.RegularidadEntity;
@@ -17,10 +17,10 @@ import um.facultad.rest.repository.RegularidadRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class RegularidadService {
 
-	@Autowired
-	private RegularidadRepository repository;
+	private final RegularidadRepository repository;
 
 	public List<RegularidadEntity> findAllByMaterias(BigDecimal personaId, Integer documentoId, Integer facultadId,
                                                      Integer planId, List<String> materiaIds) {

--- a/src/main/java/um/facultad/rest/service/SetupApiService.java
+++ b/src/main/java/um/facultad/rest/service/SetupApiService.java
@@ -3,7 +3,7 @@
  */
 package um.facultad.rest.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.exception.SetupApiException;
@@ -15,9 +15,9 @@ import um.facultad.rest.repository.SetupApiRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class SetupApiService {
-	@Autowired
-	private SetupApiRepository repository;
+	private final SetupApiRepository repository;
 
 	public SetupApiEntity findLast() {
 		return repository.findTopByOrderBySetupId().orElseThrow(() -> new SetupApiException());

--- a/src/main/java/um/facultad/rest/service/TituloEntregaService.java
+++ b/src/main/java/um/facultad/rest/service/TituloEntregaService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service;
 
+import lombok.RequiredArgsConstructor;
 import java.math.BigDecimal;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.exception.TituloEntregaException;
@@ -17,10 +17,10 @@ import um.facultad.rest.repository.TituloEntregaRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class TituloEntregaService {
 
-	@Autowired
-	private TituloEntregaRepository repository;
+	private final TituloEntregaRepository repository;
 
 	public TituloEntregaEntity findByUnique(BigDecimal personaId, Integer documentoId, Integer facultadId, Integer planId,
                                             Integer carreraId) {

--- a/src/main/java/um/facultad/rest/service/facade/MailService.java
+++ b/src/main/java/um/facultad/rest/service/facade/MailService.java
@@ -9,6 +9,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -30,22 +31,13 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class MailService {
 
 	private final InscriptosToXlsService xlsService;
 	private final JavaMailSender sender;
 	private final MateriaService materiaService;
 	private final AlumnoExamenService alumnoExamenService;
-
-	public MailService(InscriptosToXlsService xlsService,
-					   JavaMailSender sender,
-					   MateriaService materiaService,
-					   AlumnoExamenService alumnoExamenService) {
-		this.xlsService = xlsService;
-		this.sender = sender;
-		this.materiaService = materiaService;
-		this.alumnoExamenService = alumnoExamenService;
-	}
 
 	public String sendLista(Integer facultadId, Integer lectivoId, Integer planId, String materiaId, Integer cursoId,
 			Integer periodoId, Integer divisionId, Integer geograficaId, String email) throws MessagingException {

--- a/src/main/java/um/facultad/rest/service/view/InscriptoCursoService.java
+++ b/src/main/java/um/facultad/rest/service/view/InscriptoCursoService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -17,10 +17,10 @@ import um.facultad.rest.repository.view.IInscriptoCursoRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class InscriptoCursoService {
 
-	@Autowired
-	private IInscriptoCursoRepository repository;
+	private final IInscriptoCursoRepository repository;
 
 	public List<InscriptoCurso> findAllByLectivo(Integer facultadId, Integer lectivoId, Integer geograficaId) {
 		return repository.findAllByFacultadIdAndLectivoIdAndGeograficaId(facultadId, lectivoId, geograficaId,

--- a/src/main/java/um/facultad/rest/service/view/InscriptoMateriaService.java
+++ b/src/main/java/um/facultad/rest/service/view/InscriptoMateriaService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -17,9 +17,9 @@ import um.facultad.rest.repository.view.IInscriptoMateriaRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class InscriptoMateriaService {
-	@Autowired
-	private IInscriptoMateriaRepository repository;
+	private final IInscriptoMateriaRepository repository;
 
 	public List<InscriptoMateria> findAllByDivision(Integer facultadId, Integer lectivoId, Integer planId,
 			String materiaId, Integer cursoId, Integer periodoId, Integer divisionId, Integer geograficaId) {

--- a/src/main/java/um/facultad/rest/service/view/LegajoKeyService.java
+++ b/src/main/java/um/facultad/rest/service/view/LegajoKeyService.java
@@ -3,10 +3,10 @@
  */
 package um.facultad.rest.service.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 import java.util.Set;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.model.view.LegajoKey;
@@ -17,10 +17,10 @@ import um.facultad.rest.repository.view.ILegajoKeyRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class LegajoKeyService {
 
-	@Autowired
-	private ILegajoKeyRepository repository;
+	private final ILegajoKeyRepository repository;
 
 	public List<LegajoKey> findAllByFacultadIdAndIntercambioAndNumerolegajoAndPersonakeyIn(Integer facultadId,
 			Byte intercambio, Long numerolegajo, Set<String> keys) {

--- a/src/main/java/um/facultad/rest/service/view/PersonaKeyService.java
+++ b/src/main/java/um/facultad/rest/service/view/PersonaKeyService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.model.view.PersonaKey;
@@ -16,10 +16,10 @@ import um.facultad.rest.repository.view.IPersonaKeyRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class PersonaKeyService {
 
-	@Autowired
-	private IPersonaKeyRepository repository;
+	private final IPersonaKeyRepository repository;
 
 	public List<PersonaKey> findAllByUnifieds(List<String> unifieds) {
 		return repository.findAllByUnifiedIn(unifieds);

--- a/src/main/java/um/facultad/rest/service/view/PreunivCarreraService.java
+++ b/src/main/java/um/facultad/rest/service/view/PreunivCarreraService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.model.view.PreunivCarrera;
@@ -16,10 +16,10 @@ import um.facultad.rest.repository.view.IPreunivCarreraRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class PreunivCarreraService {
 
-	@Autowired
-	private IPreunivCarreraRepository repository;
+	private final IPreunivCarreraRepository repository;
 
 	public List<PreunivCarrera> findAllByCarrera(Integer facultadId, Integer lectivoId, Integer geograficaId,
 			Integer turnoId, Integer planId, Integer carreraId) {

--- a/src/main/java/um/facultad/rest/service/view/PreunivMatricResumenService.java
+++ b/src/main/java/um/facultad/rest/service/view/PreunivMatricResumenService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.model.view.PreunivMatricResumen;
@@ -16,10 +16,10 @@ import um.facultad.rest.repository.view.IPreunivMatricResumenRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class PreunivMatricResumenService {
 
-	@Autowired
-	private IPreunivMatricResumenRepository repository;
+	private final IPreunivMatricResumenRepository repository;
 
 	public List<PreunivMatricResumen> findAllByLectivo(Integer facultadId, Integer lectivoId) {
 		return repository.findAllByFacultadIdAndLectivoId(facultadId, lectivoId);

--- a/src/main/java/um/facultad/rest/service/view/PreunivResumenService.java
+++ b/src/main/java/um/facultad/rest/service/view/PreunivResumenService.java
@@ -3,9 +3,9 @@
  */
 package um.facultad.rest.service.view;
 
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -17,10 +17,10 @@ import um.facultad.rest.repository.view.IPreunivResumenRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class PreunivResumenService {
 
-	@Autowired
-	private IPreunivResumenRepository repository;
+	private final IPreunivResumenRepository repository;
 
 	public List<PreunivResumen> findAllByLectivo(Integer facultadId, Integer lectivoId) {
 		return repository.findAllByFacultadIdAndLectivoId(facultadId, lectivoId, Sort.by("geograficaId").ascending()


### PR DESCRIPTION
Closes #56

## Descripción

Migración integral de la inyección de dependencias por campo (`@Autowired`) a inyección por constructor mediante `@RequiredArgsConstructor` en **47 clases** (20 controladores, 26 servicios y 1 repositorio hexagonal), junto con limpieza de código, bump de versión a `1.6.1` y actualización de documentación. No cambia funcionalidad ni contratos de API.

## Cambios Realizados

- [ ] `refactor(di)`: migra de `@Autowired` a inyección por constructor (`@RequiredArgsConstructor`) en 47 clases (`private final X`). Incluye traslado de `@Qualifier("personasPersonaMapper")` al campo en `MatriculacionContextRepositoryImpl` y eliminación de constructores redundantes en `MailService` y `FormularioController`.
- [ ] `refactor(inscripcion)`: sustituye `new ResponseEntity<>(..., HttpStatus.OK)` por `ResponseEntity.ok(...)` en 4 endpoints de `InscripcionController` y elimina la causa redundante en `ResponseStatusException` de `findByUnique`.
- [ ] `chore(release)`: bump de versión `1.6.0` → `1.6.1` en `pom.xml`; actualización de `README.md` y `CHANGELOG.md`.
- [ ] `docs(diagrams)`: corrige variables en `flujo-inscripcion.mmd` y reestructura `despliegue-infraestructura.mmd`.

## Verificación

- [ ] Compilar el proyecto y validar que el contexto de Spring se levanta correctamente.
- [ ] Ejecutar la suite de tests existente.
- [ ] Confirmar ausencia de `@Autowired` residual en las 47 clases migradas.
