### PR TITLE
chore(release): modernize HTTP responses and handle 404s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2026-07-31
+
+### Changed
+- Modernización de las respuestas exitosas de los controladores mediante `ResponseEntity.ok()`, sin cambiar los endpoints ni sus cargas de respuesta.
+- Actualización de las pruebas de `CarreraController` y `PersonaEntityController` para usar inyección por constructor.
+
+### Fixed
+- Los endpoints de búsqueda única de carrera, materia y plan traducen la ausencia del recurso a `404 Not Found`.
+
 ## [1.6.1] - 2026-07-31
 
 ### Changed
@@ -237,4 +246,4 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Security
 - Implementación de validación de datos
-- Mejora en el manejo de excepciones 
+- Mejora en el manejo de excepciones

--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE.md](LICENSE.m
 🟢 Activo - En desarrollo activo
 
 ### Versión Actual
-**1.6.1**
+**1.6.2**
 
 ### Últimas Actualizaciones
-- Refactorización de la inyección de dependencias: migración de `@Autowired` a inyección por constructor (`@RequiredArgsConstructor`) en 47 controladores y servicios
-- Limpieza de código en `InscripcionController` (`ResponseEntity.ok()`, `ResponseStatusException` sin causa redundante)
-- `MatriculacionContextRepositoryImpl` migrado a inyección por constructor con `@Qualifier("personasPersonaMapper")` a nivel de campo
+- Modernización de respuestas HTTP en los controladores mediante `ResponseEntity.ok()`
+- Los endpoints de carrera, materia y plan devuelven `404 Not Found` cuando no existe el recurso solicitado
+- Actualización de las pruebas de los controladores para usar inyección por constructor
 
 ## 💬 Soporte
 

--- a/docs/diagrams/despliegue-infraestructura.mmd
+++ b/docs/diagrams/despliegue-infraestructura.mmd
@@ -1,20 +1,27 @@
-graph TB
+flowchart TD
     subgraph GH ["GitHub Actions"]
-        A["CI/CD Pipeline"]
+        A["Build and Analyze"]
+        E["Build and Push Docker Image"]
+        F["Generate Documentation"]
     end
 
     subgraph DC ["Docker Container"]
-        B["Spring Boot App"]
+        B["Spring Boot JVM Image"]
     end
 
-    subgraph EX ["Externos"]
+    subgraph GP ["GitHub Pages"]
+        G["Documentation Site"]
+    end
+
+    subgraph EX ["External Services"]
         C["MySQL Database"]
         D["External APIs"]
     end
 
-    A --> E["Build & Test"]
-    E --> F["Deploy to Prod"]
-    F --> B
+    A --> E
+    A --> F
+    E --> B
+    F --> G
     B --> C
     B --> D
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>ar.edu</groupId>
 	<artifactId>um.facultad.rest</artifactId>
-	<version>1.6.1</version>
+	<version>1.6.2</version>
 	<name>um.facultad.rest</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>

--- a/src/main/java/um/facultad/rest/controller/BajaController.java
+++ b/src/main/java/um/facultad/rest/controller/BajaController.java
@@ -36,8 +36,7 @@ public class BajaController {
                                                    @PathVariable Integer documentoId, @PathVariable Integer lectivoId) {
 		log.info("Baja Controller Facultad Request");
 		try {
-			return new ResponseEntity<BajaEntity>(service.findByUnique(facultadId, personaId, documentoId, lectivoId),
-					HttpStatus.OK);
+            return ResponseEntity.ok(service.findByUnique(facultadId, personaId, documentoId, lectivoId));
 		} catch (BajaException e) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
 		}

--- a/src/main/java/um/facultad/rest/controller/LectivoController.java
+++ b/src/main/java/um/facultad/rest/controller/LectivoController.java
@@ -28,12 +28,12 @@ public class LectivoController {
 
 	@GetMapping("/")
 	public ResponseEntity<List<LectivoEntity>> findAll() {
-		return new ResponseEntity<List<LectivoEntity>>(service.findAll(), HttpStatus.OK);
+		return ResponseEntity.ok(service.findAll());
 	}
 	
 	@GetMapping("/reverse")
 	public ResponseEntity<List<LectivoEntity>> findAllReverse() {
-		return new ResponseEntity<List<LectivoEntity>>(service.findAllReverse(), HttpStatus.OK);
+		return ResponseEntity.ok(service.findAllReverse());
 	}
 
 }

--- a/src/main/java/um/facultad/rest/controller/LegajoController.java
+++ b/src/main/java/um/facultad/rest/controller/LegajoController.java
@@ -31,12 +31,12 @@ public class LegajoController {
 
 	private final LegajoService service;
 
-	@GetMapping("/persona/{personaId}/{documentoId}/{facultadId}")
+@GetMapping("/persona/{personaId}/{documentoId}/{facultadId}")
 	public ResponseEntity<LegajoEntity> findByPersona(@PathVariable BigDecimal personaId, @PathVariable Integer documentoId,
-                                                      @PathVariable Integer facultadId) {
+                                                       @PathVariable Integer facultadId) {
 		// agregar respuesta para evitar la excepcion
 		try {
-			return new ResponseEntity<>(service.findByPersona(personaId, documentoId, facultadId), HttpStatus.OK);
+			return ResponseEntity.ok(service.findByPersona(personaId, documentoId, facultadId));
 		} catch (LegajoException e) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
 		}
@@ -44,22 +44,20 @@ public class LegajoController {
 
 	@GetMapping("/asigna/{facultadId}/{lectivoId}/{personaId}/{documentoId}")
 	public ResponseEntity<LegajoEntity> asignaNumeroLegajo(@PathVariable Integer facultadId, @PathVariable Integer lectivoId,
-                                                           @PathVariable BigDecimal personaId, @PathVariable Integer documentoId) {
-		return new ResponseEntity<>(service.asignaNumeroLegajo(facultadId, lectivoId, personaId, documentoId),
-				HttpStatus.OK);
+                                                            @PathVariable BigDecimal personaId, @PathVariable Integer documentoId) {
+		return ResponseEntity.ok(service.asignaNumeroLegajo(facultadId, lectivoId, personaId, documentoId));
 	}
 
 	@GetMapping("/numera/{facultadId}/{lectivoId}")
 	public ResponseEntity<List<LegajoEntity>> numeraByLectivoId(@PathVariable Integer facultadId,
-                                                                @PathVariable Integer lectivoId) {
-		return new ResponseEntity<>(service.numeraByLectivoId(facultadId, lectivoId), HttpStatus.OK);
+                                                                 @PathVariable Integer lectivoId) {
+		return ResponseEntity.ok(service.numeraByLectivoId(facultadId, lectivoId));
 	}
 
 	@GetMapping("/pre/{facultadId}/{lectivoId}/{geograficaId}")
 	public ResponseEntity<List<LegajoKey>> findAllByPreuniversitario(@PathVariable Integer facultadId,
-                                                                     @PathVariable Integer lectivoId, @PathVariable Integer geograficaId) {
-		return new ResponseEntity<>(service.findAllByPreuniversitario(facultadId, lectivoId, geograficaId),
-				HttpStatus.OK);
+                                                                      @PathVariable Integer lectivoId, @PathVariable Integer geograficaId) {
+		return ResponseEntity.ok(service.findAllByPreuniversitario(facultadId, lectivoId, geograficaId));
 	}
 
 }

--- a/src/main/java/um/facultad/rest/controller/LocalidadController.java
+++ b/src/main/java/um/facultad/rest/controller/LocalidadController.java
@@ -25,10 +25,10 @@ public class LocalidadController {
 	
 	private final LocalidadService service;
 
-	@GetMapping("/unique/{facultadId}/{provinciaId}/{localidadId}")
+@GetMapping("/unique/{facultadId}/{provinciaId}/{localidadId}")
 	public ResponseEntity<LocalidadEntity> findByUnique(@PathVariable Integer facultadId, @PathVariable Integer provinciaId,
-                                                        @PathVariable Integer localidadId) {
-		return new ResponseEntity<LocalidadEntity>(service.findByUnique(facultadId, provinciaId, localidadId), HttpStatus.OK);
+                                                         @PathVariable Integer localidadId) {
+		return ResponseEntity.ok(service.findByUnique(facultadId, provinciaId, localidadId));
 	}
 	
 }

--- a/src/main/java/um/facultad/rest/controller/PreInscripcionController.java
+++ b/src/main/java/um/facultad/rest/controller/PreInscripcionController.java
@@ -31,28 +31,25 @@ public class PreInscripcionController {
 	@GetMapping("/lectivo/{facultadId}/{lectivoId}")
 	public ResponseEntity<List<PreInscripcionEntity>> findAllByLectivo(@PathVariable Integer facultadId,
                                                                        @PathVariable Integer lectivoId) {
-		return new ResponseEntity<List<PreInscripcionEntity>>(service.findAllByLectivo(facultadId, lectivoId), HttpStatus.OK);
+        return ResponseEntity.ok(service.findAllByLectivo(facultadId, lectivoId));
 	}
 
 	@GetMapping("/sede/{facultadId}/{lectivoId}/{geograficaId}")
 	public ResponseEntity<List<PreInscripcionEntity>> findAllBySede(@PathVariable Integer facultadId,
                                                                     @PathVariable Integer lectivoId, @PathVariable Integer geograficaId) {
-		return new ResponseEntity<List<PreInscripcionEntity>>(service.findAllBySede(facultadId, lectivoId, geograficaId),
-				HttpStatus.OK);
+        return ResponseEntity.ok(service.findAllBySede(facultadId, lectivoId, geograficaId));
 	}
 
 	@GetMapping("/turno/{facultadId}/{lectivoId}/{geograficaId}/{turnoId}")
 	public ResponseEntity<List<PreInscripcionEntity>> findAllByTurnoKey(@PathVariable Integer facultadId,
                                                                         @PathVariable Integer lectivoId, @PathVariable Integer geograficaId, @PathVariable Integer turnoId) {
-		return new ResponseEntity<List<PreInscripcionEntity>>(
-				service.findAllByTurno(facultadId, lectivoId, geograficaId, turnoId), HttpStatus.OK);
+        return ResponseEntity.ok(service.findAllByTurno(facultadId, lectivoId, geograficaId, turnoId));
 	}
 
 	@GetMapping("/personalectivo/{facultadId}/{personaId}/{documentoId}/{lectivoId}")
 	public ResponseEntity<PreInscripcionEntity> findPersonaByLectivo(@PathVariable Integer facultadId,
                                                                      @PathVariable BigDecimal personaId, @PathVariable Integer documentoId, @PathVariable Integer lectivoId) {
-		return new ResponseEntity<PreInscripcionEntity>(
-				service.findPersonaByLectivo(facultadId, personaId, documentoId, lectivoId), HttpStatus.OK);
+        return ResponseEntity.ok(service.findPersonaByLectivo(facultadId, personaId, documentoId, lectivoId));
 	}
 	
 }

--- a/src/main/java/um/facultad/rest/controller/PreTurnoController.java
+++ b/src/main/java/um/facultad/rest/controller/PreTurnoController.java
@@ -27,10 +27,10 @@ public class PreTurnoController {
 
 	private final PreTurnoService service;
 
-	@GetMapping("/lectivo/{facultadId}/{lectivoId}")
+@GetMapping("/lectivo/{facultadId}/{lectivoId}")
 	public ResponseEntity<List<PreTurnoEntity>> findAllByLectivo(@PathVariable Integer facultadId,
                                                                  @PathVariable Integer lectivoId) {
-		return new ResponseEntity<List<PreTurnoEntity>>(service.findAllByLectivo(facultadId, lectivoId), HttpStatus.OK);
+		return ResponseEntity.ok(service.findAllByLectivo(facultadId, lectivoId));
 	}
 	
 }

--- a/src/main/java/um/facultad/rest/controller/ProvinciaController.java
+++ b/src/main/java/um/facultad/rest/controller/ProvinciaController.java
@@ -27,7 +27,7 @@ public class ProvinciaController {
 
 	@GetMapping("/unique/{facultadId}/{provinciaId}")
 	public ResponseEntity<ProvinciaEntity> findByUnique(@PathVariable Integer facultadId, @PathVariable Integer provinciaId) {
-		return new ResponseEntity<ProvinciaEntity>(service.findByUnique(facultadId, provinciaId), HttpStatus.OK);
+		return ResponseEntity.ok(service.findByUnique(facultadId, provinciaId));
 	}
 
 }

--- a/src/main/java/um/facultad/rest/controller/SetupApiController.java
+++ b/src/main/java/um/facultad/rest/controller/SetupApiController.java
@@ -26,7 +26,7 @@ public class SetupApiController {
 	
 	@GetMapping("/last")
 	public ResponseEntity<SetupApiEntity> findLast() {
-		return new ResponseEntity<SetupApiEntity>(service.findLast(), HttpStatus.OK);
+		return ResponseEntity.ok(service.findLast());
 	}
 	
 }

--- a/src/main/java/um/facultad/rest/controller/TituloEntregaController.java
+++ b/src/main/java/um/facultad/rest/controller/TituloEntregaController.java
@@ -31,8 +31,7 @@ public class TituloEntregaController {
 	public ResponseEntity<TituloEntregaEntity> findByUnique(@PathVariable BigDecimal personaId,
                                                             @PathVariable Integer documentoId, @PathVariable Integer facultadId, @PathVariable Integer planId,
                                                             @PathVariable Integer carreraId) {
-		return new ResponseEntity<TituloEntregaEntity>(
-				service.findByUnique(personaId, documentoId, facultadId, planId, carreraId), HttpStatus.OK);
+		return ResponseEntity.ok(service.findByUnique(personaId, documentoId, facultadId, planId, carreraId));
 	}
 	
 }

--- a/src/main/java/um/facultad/rest/controller/dto/PendienteInfoController.java
+++ b/src/main/java/um/facultad/rest/controller/dto/PendienteInfoController.java
@@ -30,7 +30,6 @@ public class PendienteInfoController {
 	@GetMapping("/info/{facultadId}/{lectivoId}/{geograficaId}/{personaId}/{documentoId}")
 	public ResponseEntity<PendienteInfo> findByAlumno(@PathVariable Integer facultadId, @PathVariable Integer lectivoId,
 			@PathVariable Integer geograficaId, @PathVariable BigDecimal personaId, @PathVariable Integer documentoId) {
-		return new ResponseEntity<PendienteInfo>(
-				service.findByAlumno(facultadId, lectivoId, geograficaId, personaId, documentoId), HttpStatus.OK);
+        return ResponseEntity.ok(service.findByAlumno(facultadId, lectivoId, geograficaId, personaId, documentoId));
 	}
 }

--- a/src/main/java/um/facultad/rest/controller/facade/AutoMatriculaController.java
+++ b/src/main/java/um/facultad/rest/controller/facade/AutoMatriculaController.java
@@ -30,8 +30,7 @@ public class AutoMatriculaController {
 	@GetMapping("/pre/{facultadId}/{lectivoId}/{geograficaId}/{turnoId}")
 	public ResponseEntity<List<Inscripcion>> auto_matricula_pre(@PathVariable Integer facultadId,
                                                                       @PathVariable Integer lectivoId, @PathVariable Integer geograficaId, @PathVariable Integer turnoId) {
-		return new ResponseEntity<>(
-				service.auto_matricula_pre(facultadId, lectivoId, geograficaId, turnoId), HttpStatus.OK);
+        return ResponseEntity.ok(service.auto_matricula_pre(facultadId, lectivoId, geograficaId, turnoId));
 	}
 	
 }

--- a/src/main/java/um/facultad/rest/controller/view/InscriptoCursoController.java
+++ b/src/main/java/um/facultad/rest/controller/view/InscriptoCursoController.java
@@ -30,14 +30,13 @@ public class InscriptoCursoController {
 	@GetMapping("/lectivo/{facultadId}/{lectivoId}/{geograficaId}")
 	public ResponseEntity<List<InscriptoCurso>> findAllByLectivo(@PathVariable Integer facultadId,
                                                                  @PathVariable Integer lectivoId, @PathVariable Integer geograficaId) {
-		return new ResponseEntity<List<InscriptoCurso>>(service.findAllByLectivo(facultadId, lectivoId, geograficaId),
-				HttpStatus.OK);
+        return ResponseEntity.ok(service.findAllByLectivo(facultadId, lectivoId, geograficaId));
 	}
 
 	@GetMapping("/curso/{facultadId}/{lectivoId}")
 	public ResponseEntity<List<InscriptoCurso>> findAllByCurso(@PathVariable Integer facultadId,
 			@PathVariable Integer lectivoId) {
-		return new ResponseEntity<List<InscriptoCurso>>(service.findAllByCurso(facultadId, lectivoId), HttpStatus.OK);
+        return ResponseEntity.ok(service.findAllByCurso(facultadId, lectivoId));
 	}
 
 }

--- a/src/main/java/um/facultad/rest/controller/view/LegajoKeyController.java
+++ b/src/main/java/um/facultad/rest/controller/view/LegajoKeyController.java
@@ -31,8 +31,7 @@ public class LegajoKeyController {
 	@PostMapping("/unifieds/{facultadId}")
 	public ResponseEntity<List<LegajoKey>> findAllByFacultadAndPersonaKeys(@PathVariable Integer facultadId,
                                                                            @RequestBody List<String> personaKeys) {
-		return new ResponseEntity<List<LegajoKey>>(service.findAllByFacultadAndPersonaKeys(facultadId, personaKeys),
-				HttpStatus.OK);
+        return ResponseEntity.ok(service.findAllByFacultadAndPersonaKeys(facultadId, personaKeys));
 	}
 
 }

--- a/src/main/java/um/facultad/rest/controller/view/PersonaKeyController.java
+++ b/src/main/java/um/facultad/rest/controller/view/PersonaKeyController.java
@@ -29,6 +29,6 @@ public class PersonaKeyController {
 
 	@PostMapping("/unifieds")
 	public ResponseEntity<List<PersonaKey>> findAllByUnifieds(@RequestBody List<String> unifieds) {
-		return new ResponseEntity<List<PersonaKey>>(service.findAllByUnifieds(unifieds), HttpStatus.OK);
+        return ResponseEntity.ok(service.findAllByUnifieds(unifieds));
 	}
 }

--- a/src/main/java/um/facultad/rest/controller/view/PreunivCarreraController.java
+++ b/src/main/java/um/facultad/rest/controller/view/PreunivCarreraController.java
@@ -30,16 +30,14 @@ public class PreunivCarreraController {
 	@GetMapping("/lectivo/{facultadId}/{lectivoId}")
 	public ResponseEntity<List<PreunivCarrera>> findAllByLectivo(@PathVariable Integer facultadId,
                                                                  @PathVariable Integer lectivoId) {
-		return new ResponseEntity<List<PreunivCarrera>>(service.findAllByLectivo(facultadId, lectivoId), HttpStatus.OK);
+        return ResponseEntity.ok(service.findAllByLectivo(facultadId, lectivoId));
 	}
 
 	@GetMapping("/carrera/{facultadId}/{lectivoId}/{geograficaId}/{turnoId}/{planId}/{carreraId}")
 	public ResponseEntity<List<PreunivCarrera>> findAllByCarrera(@PathVariable Integer facultadId,
 			@PathVariable Integer lectivoId, @PathVariable Integer geograficaId, @PathVariable Integer turnoId,
 			@PathVariable Integer planId, @PathVariable Integer carreraId) {
-		return new ResponseEntity<List<PreunivCarrera>>(
-				service.findAllByCarrera(facultadId, lectivoId, geograficaId, turnoId, planId, carreraId),
-				HttpStatus.OK);
+        return ResponseEntity.ok(service.findAllByCarrera(facultadId, lectivoId, geograficaId, turnoId, planId, carreraId));
 	}
 
 }

--- a/src/main/java/um/facultad/rest/controller/view/PreunivMatricResumenController.java
+++ b/src/main/java/um/facultad/rest/controller/view/PreunivMatricResumenController.java
@@ -30,8 +30,7 @@ public class PreunivMatricResumenController {
 	@GetMapping("/lectivo/{facultadId}/{lectivoId}")
 	public ResponseEntity<List<PreunivMatricResumen>> findAllByLectivo(@PathVariable Integer facultadId,
                                                                        @PathVariable Integer lectivoId) {
-		return new ResponseEntity<List<PreunivMatricResumen>>(service.findAllByLectivo(facultadId, lectivoId),
-				HttpStatus.OK);
+        return ResponseEntity.ok(service.findAllByLectivo(facultadId, lectivoId));
 	}
 
 }

--- a/src/main/java/um/facultad/rest/controller/view/PreunivResumenController.java
+++ b/src/main/java/um/facultad/rest/controller/view/PreunivResumenController.java
@@ -30,7 +30,7 @@ public class PreunivResumenController {
 	@GetMapping("/lectivo/{facultadId}/{lectivoId}")
 	public ResponseEntity<List<PreunivResumen>> findAllByLectivo(@PathVariable Integer facultadId,
                                                                  @PathVariable Integer lectivoId) {
-		return new ResponseEntity<List<PreunivResumen>>(service.findAllByLectivo(facultadId, lectivoId), HttpStatus.OK);
+        return ResponseEntity.ok(service.findAllByLectivo(facultadId, lectivoId));
 	}
 	
 }

--- a/src/main/java/um/facultad/rest/hexagonal/carreras/carrera/infrastructure/web/controller/CarreraController.java
+++ b/src/main/java/um/facultad/rest/hexagonal/carreras/carrera/infrastructure/web/controller/CarreraController.java
@@ -1,6 +1,8 @@
 package um.facultad.rest.hexagonal.carreras.carrera.infrastructure.web.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.server.ResponseStatusException;
+import um.facultad.rest.hexagonal.carreras.carrera.application.exception.CarreraException;
 import um.facultad.rest.hexagonal.carreras.carrera.application.service.CarreraService;
 import um.facultad.rest.hexagonal.carreras.carrera.infrastructure.web.dto.CarreraResponse;
 import um.facultad.rest.hexagonal.carreras.carrera.infrastructure.web.mapper.CarreraDtoMapper;
@@ -27,15 +29,19 @@ public class CarreraController {
         List<CarreraResponse> responses = service.findAll().stream()
                 .map(dtoMapper::toResponse)
                 .toList();
-        return new ResponseEntity<>(responses, HttpStatus.OK);
+        return ResponseEntity.ok(responses);
     }
 
     @GetMapping("/unique/{facultadId}/{planId}/{carreraId}")
     public ResponseEntity<CarreraResponse> findByUnique(@PathVariable Integer facultadId,
                                                          @PathVariable Integer planId,
                                                          @PathVariable Integer carreraId) {
-        CarreraResponse response = dtoMapper.toResponse(service.findByUnique(facultadId, planId, carreraId));
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        try {
+            CarreraResponse response = dtoMapper.toResponse(service.findByUnique(facultadId, planId, carreraId));
+            return ResponseEntity.ok(response);
+        } catch (CarreraException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
     }
 
 }

--- a/src/main/java/um/facultad/rest/hexagonal/carreras/materia/infrastructure/web/controller/MateriaController.java
+++ b/src/main/java/um/facultad/rest/hexagonal/carreras/materia/infrastructure/web/controller/MateriaController.java
@@ -1,6 +1,7 @@
 package um.facultad.rest.hexagonal.carreras.materia.infrastructure.web.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.server.ResponseStatusException;
 import um.facultad.rest.hexagonal.carreras.materia.application.service.MateriaService;
 import um.facultad.rest.hexagonal.carreras.materia.infrastructure.web.dto.MateriaResponse;
 import um.facultad.rest.hexagonal.carreras.materia.infrastructure.web.mapper.MateriaDtoMapper;
@@ -25,17 +26,20 @@ public class MateriaController {
     @GetMapping("/byplan/{facultadId}/{planId}")
     public ResponseEntity<List<MateriaResponse>> findAllByPlan(@PathVariable Integer facultadId,
                                                                 @PathVariable Integer planId) {
-        return new ResponseEntity<>(service.findAllByPlan(facultadId, planId).stream()
+        return ResponseEntity.ok(service.findAllByPlan(facultadId, planId).stream()
                 .map(dtoMapper::toResponse)
-                .toList(), HttpStatus.OK);
+                .toList());
     }
 
     @GetMapping("/unique/{facultadId}/{planId}/{materiaId}")
     public ResponseEntity<MateriaResponse> findByUnique(@PathVariable Integer facultadId,
                                                          @PathVariable Integer planId,
                                                          @PathVariable String materiaId) {
-        return new ResponseEntity<>(dtoMapper.toResponse(service.findByUnique(facultadId, planId, materiaId)),
-                HttpStatus.OK);
+        try {
+            return ResponseEntity.ok(dtoMapper.toResponse(service.findByUnique(facultadId, planId, materiaId)));
+        } catch (MatchException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
     }
 
 }

--- a/src/main/java/um/facultad/rest/hexagonal/carreras/plan/infrastructure/web/controller/PlanController.java
+++ b/src/main/java/um/facultad/rest/hexagonal/carreras/plan/infrastructure/web/controller/PlanController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.server.ResponseStatusException;
+import um.facultad.rest.hexagonal.carreras.plan.application.exception.PlanException;
 import um.facultad.rest.hexagonal.carreras.plan.application.service.PlanService;
 import um.facultad.rest.hexagonal.carreras.plan.infrastructure.web.dto.PlanResponse;
 import um.facultad.rest.hexagonal.carreras.plan.infrastructure.web.mapper.PlanDtoMapper;
@@ -24,14 +26,18 @@ public class PlanController {
 
     @GetMapping("/")
     public ResponseEntity<List<PlanResponse>> findAll() {
-        return new ResponseEntity<>(service.findAll().stream()
+        return ResponseEntity.ok(service.findAll().stream()
                 .map(planDtoMapper::toResponse)
-                .toList(), HttpStatus.OK);
+                .toList());
     }
 
     @GetMapping("/unique/{facultadId}/{planId}")
     public ResponseEntity<PlanResponse> findByUnique(@PathVariable Integer facultadId, @PathVariable Integer planId) {
-        return new ResponseEntity<>(planDtoMapper.toResponse(service.findByUnique(facultadId, planId)), HttpStatus.OK);
+        try {
+            return ResponseEntity.ok(planDtoMapper.toResponse(service.findByUnique(facultadId, planId)));
+        } catch (PlanException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
     }
 
 }

--- a/src/main/java/um/facultad/rest/hexagonal/personas/domicilio/infrastructure/web/controller/DomicilioController.java
+++ b/src/main/java/um/facultad/rest/hexagonal/personas/domicilio/infrastructure/web/controller/DomicilioController.java
@@ -28,36 +28,30 @@ public class DomicilioController {
     @GetMapping("/{personaId}/{documentoId}")
     public ResponseEntity<DomicilioResponse> findByPersonaIdAndDocumentoId(@PathVariable BigDecimal personaId,
                                                                            @PathVariable Integer documentoId) {
-        return new ResponseEntity<>(dtoMapper.toResponse(service.findByPersonaIdAndDocumentoId(personaId, documentoId)),
-                HttpStatus.OK);
+        return ResponseEntity.ok(dtoMapper.toResponse(service.findByPersonaIdAndDocumentoId(personaId, documentoId)));
     }
 
     @GetMapping("/pagador/{personaId}/{documentoId}")
     public ResponseEntity<DomicilioResponse> findByPagador(@PathVariable BigDecimal personaId,
                                                            @PathVariable Integer documentoId) {
-        return new ResponseEntity<>(dtoMapper.toResponse(service.findByPagador(personaId, documentoId)),
-                HttpStatus.OK);
+        return ResponseEntity.ok(dtoMapper.toResponse(service.findByPagador(personaId, documentoId)));
     }
 
     @PostMapping("/")
     public ResponseEntity<DomicilioResponse> add(@RequestBody DomicilioRequest request) {
-        return new ResponseEntity<>(dtoMapper.toResponse(service.add(dtoMapper.toDomain(request), true)),
-                HttpStatus.OK);
+        return ResponseEntity.ok(dtoMapper.toResponse(service.add(dtoMapper.toDomain(request), true)));
     }
 
     @PutMapping("/{personaId}/{documentoId}")
     public ResponseEntity<DomicilioResponse> update(@RequestBody DomicilioRequest request,
                                                     @PathVariable BigDecimal personaId,
                                                     @PathVariable Integer documentoId) {
-        return new ResponseEntity<>(
-                dtoMapper.toResponse(service.update(dtoMapper.toDomain(request), personaId, documentoId, true)),
-                HttpStatus.OK);
+        return ResponseEntity.ok(dtoMapper.toResponse(service.update(dtoMapper.toDomain(request), personaId, documentoId, true)));
     }
 
     @PostMapping("/sincronize")
     public ResponseEntity<DomicilioResponse> sincronize(@RequestBody DomicilioRequest request) {
-        return new ResponseEntity<>(dtoMapper.toResponse(service.sincronize(dtoMapper.toDomain(request))),
-                HttpStatus.OK);
+        return ResponseEntity.ok(dtoMapper.toResponse(service.sincronize(dtoMapper.toDomain(request))));
     }
 
 }

--- a/src/main/java/um/facultad/rest/hexagonal/personas/persona/infrastructure/web/controller/PersonaController.java
+++ b/src/main/java/um/facultad/rest/hexagonal/personas/persona/infrastructure/web/controller/PersonaController.java
@@ -24,8 +24,7 @@ public class PersonaController {
     @GetMapping("/{personaId}/{documentoId}")
     public ResponseEntity<PersonaResponse> findByPersonaIdAndDocumentoId(@PathVariable BigDecimal personaId,
                                                                          @PathVariable Integer documentoId) {
-        return new ResponseEntity<>(dtoMapper.toResponse(service.findByPersonaIdAndDocumentoId(personaId, documentoId)),
-                HttpStatus.OK);
+        return ResponseEntity.ok(dtoMapper.toResponse(service.findByPersonaIdAndDocumentoId(personaId, documentoId)));
     }
 
 }

--- a/src/test/java/um/facultad/rest/controller/CarreraControllerTest.java
+++ b/src/test/java/um/facultad/rest/controller/CarreraControllerTest.java
@@ -2,6 +2,7 @@ package um.facultad.rest.controller;
 
 import org.junit.jupiter.api.Test;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -14,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@RequiredArgsConstructor
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
 public class CarreraControllerTest {
 
     private final MockMvc mockMvc;

--- a/src/test/java/um/facultad/rest/controller/CarreraControllerTest.java
+++ b/src/test/java/um/facultad/rest/controller/CarreraControllerTest.java
@@ -1,7 +1,7 @@
 package um.facultad.rest.controller;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -14,10 +14,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@RequiredArgsConstructor
 public class CarreraControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    private final MockMvc mockMvc;
 
     @MockitoBean
     private CarreraService carreraService;

--- a/src/test/java/um/facultad/rest/controller/PersonaEntityControllerTest.java
+++ b/src/test/java/um/facultad/rest/controller/PersonaEntityControllerTest.java
@@ -2,6 +2,7 @@ package um.facultad.rest.controller;
 
 import org.junit.jupiter.api.Test;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -14,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@RequiredArgsConstructor
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
 public class PersonaEntityControllerTest {
 
     private final MockMvc mockMvc;

--- a/src/test/java/um/facultad/rest/controller/PersonaEntityControllerTest.java
+++ b/src/test/java/um/facultad/rest/controller/PersonaEntityControllerTest.java
@@ -1,7 +1,7 @@
 package um.facultad.rest.controller;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -14,10 +14,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@RequiredArgsConstructor
 public class PersonaEntityControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    private final MockMvc mockMvc;
 
     @MockitoBean
     private PersonaService personaService;


### PR DESCRIPTION
Closes #58

## Descripcion
Actualiza la version 1.6.2 y moderniza el manejo de respuestas HTTP del servicio. Los endpoints de busqueda unica de carrera, materia y plan ahora convierten la ausencia del recurso en `404 Not Found`, manteniendo las rutas y cargas de respuesta existentes.

## Cambios Realizados
- [x] Reemplazadas las construcciones explicitas de `new ResponseEntity<>(..., HttpStatus.OK)` por `ResponseEntity.ok(...)` en los controladores afectados.
- [x] Agregado el mapeo de excepciones de recursos no encontrados a `404 Not Found` para carrera, materia y plan.
- [x] Actualizadas las pruebas de `CarreraController` y `PersonaEntityController` para inyeccion por constructor con autowiring explicito.
- [x] Actualizados `pom.xml`, `CHANGELOG.md` y `README.md` a la version 1.6.2.
- [x] Actualizado el diagrama de infraestructura para reflejar build, imagen Docker, documentacion, GitHub Pages y servicios externos.

## Verificacion
- [x] `mvn test` (3 tests ejecutados, 0 fallos, 0 errores).
