### PR TITLE
fix(tesoreria): release 1.6.3 with SpringDoc 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] - 2026-08-03
+
+### Changed
+- Actualización de SpringDoc OpenAPI de `3.0.3` a `3.1.0`.
+
+### Fixed
+- El endpoint `GET /tesoreriaEstado/unique/{facultadId}/{personaId}/{documentoId}` devuelve `404 Not Found` cuando no existe el estado de tesorería solicitado, en lugar de `400 Bad Request`.
+
 ## [1.6.2] - 2026-07-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Este servicio proporciona la funcionalidad core para la gestión de facultades, 
 - MySQL Connector 26.7.0
 - Apache POI 5.5.1
 - OpenPDF 3.0.5
-- SpringDoc OpenAPI 3.0.3
+- SpringDoc OpenAPI 3.1.0
 - Spring Security
 - Lombok
 - Docker
@@ -131,11 +131,13 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE.md](LICENSE.m
 🟢 Activo - En desarrollo activo
 
 ### Versión Actual
-**1.6.2**
+**1.6.3**
 
 ### Últimas Actualizaciones
 - Modernización de respuestas HTTP en los controladores mediante `ResponseEntity.ok()`
 - Los endpoints de carrera, materia y plan devuelven `404 Not Found` cuando no existe el recurso solicitado
+- El endpoint de estado de tesorería devuelve `404 Not Found` cuando no existe el recurso solicitado
+- Actualización de SpringDoc OpenAPI a `3.1.0`
 - Actualización de las pruebas de los controladores para usar inyección por constructor
 
 ## 💬 Soporte

--- a/docs/diagrams/arquitectura-facultad-service.mmd
+++ b/docs/diagrams/arquitectura-facultad-service.mmd
@@ -1,4 +1,4 @@
-graph TB
+flowchart TD
     subgraph Clientes ["Clientes"]
         A["Cliente HTTP"] --> B["Spring Security"]
     end
@@ -18,7 +18,7 @@ graph TB
         end
         C --> D
         D --> E
-        E --> F
+        F --> E
     end
 
     subgraph External ["Externo"]

--- a/docs/diagrams/flujo-inscripcion.mmd
+++ b/docs/diagrams/flujo-inscripcion.mmd
@@ -2,9 +2,9 @@ sequenceDiagram
     actor U as Usuario
     participant C as InscripcionController
     participant UC as InscripcionService
-    participant IPS as InscripcionPagoService
-    participant PS as PersonaService
-    participant DS as DomicilioService
+    participant IPS as InscripcionPagoApplicationService
+    participant PS as PersonaApplicationService
+    participant DS as DomicilioApplicationService
 
     U->>C: GET /inscripcion/full/{facultadId}/{personaId}/{documentoId}/{lectivoId}
     C->>UC: findInscripcionFull()

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>ar.edu</groupId>
 	<artifactId>um.facultad.rest</artifactId>
-	<version>1.6.2</version>
+	<version>1.6.3</version>
 	<name>um.facultad.rest</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>3.0.3</version>
+			<version>3.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.mysql</groupId>

--- a/src/main/java/um/facultad/rest/hexagonal/tesoreriaEstado/infrastructure/web/controller/TesoreriaEstadoController.java
+++ b/src/main/java/um/facultad/rest/hexagonal/tesoreriaEstado/infrastructure/web/controller/TesoreriaEstadoController.java
@@ -32,7 +32,7 @@ public class TesoreriaEstadoController {
             TesoreriaEstadoResponse response = dtoMapper.toResponse(service.findByUnique(facultadId, personaId, documentoId));
             return ResponseEntity.ok(response);
         } catch (TesoreriaEstadoException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Closes #60

## Descripción
Actualiza el proyecto a la versión 1.6.3, incorpora SpringDoc OpenAPI 3.1.0 y corrige el código HTTP del endpoint de estado de tesorería para recursos inexistentes.

## Cambios Realizados
- [x] Actualizar la versión del proyecto y SpringDoc OpenAPI a 1.6.3 y 3.1.0.
- [x] Devolver `404 Not Found` cuando no existe el estado de tesorería solicitado.
- [x] Actualizar el changelog, README y diagramas Mermaid.

## Verificación
La suite de pruebas Maven se ejecuta con `mvn test`.
