### PR TITLE
fix(pendiente-info): mejora resiliencia y publica v1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.4] - 2026-08-04
+
+### Fixed
+- `GET /pendienteinfo/info/{facultadId}/{lectivoId}/{geograficaId}/{personaId}/{documentoId}` devuelve la información disponible cuando falla la carga de una sección, usando valores vacíos para las colecciones afectadas, en lugar de interrumpir toda la respuesta.
+
+### Added
+- Pruebas unitarias para verificar la respuesta parcial ante fallos en cargas base y dependientes.
+
 ## [1.6.3] - 2026-08-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE.md](LICENSE.m
 🟢 Activo - En desarrollo activo
 
 ### Versión Actual
-**1.6.3**
+**1.6.4**
 
 ### Últimas Actualizaciones
 - Modernización de respuestas HTTP en los controladores mediante `ResponseEntity.ok()`
@@ -139,6 +139,7 @@ Este proyecto está bajo la Licencia MIT - ver el archivo [LICENSE.md](LICENSE.m
 - El endpoint de estado de tesorería devuelve `404 Not Found` cuando no existe el recurso solicitado
 - Actualización de SpringDoc OpenAPI a `3.1.0`
 - Actualización de las pruebas de los controladores para usar inyección por constructor
+- `PendienteInfoService` devuelve una respuesta parcial cuando falla la carga de una sección y registra el detalle del error
 
 ## 💬 Soporte
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>ar.edu</groupId>
 	<artifactId>um.facultad.rest</artifactId>
-	<version>1.6.3</version>
+	<version>1.6.4</version>
 	<name>um.facultad.rest</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>

--- a/src/main/java/um/facultad/rest/service/dto/PendienteInfoService.java
+++ b/src/main/java/um/facultad/rest/service/dto/PendienteInfoService.java
@@ -5,9 +5,10 @@ package um.facultad.rest.service.dto;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.function.Supplier;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import um.facultad.rest.hexagonal.inscripciones.inscripcion.domain.model.Inscripcion;
@@ -33,6 +34,7 @@ import um.facultad.rest.service.RegularidadService;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PendienteInfoService {
 
 	private final FacultadService facultadservice;
@@ -52,29 +54,69 @@ public class PendienteInfoService {
 	public PendienteInfo findByAlumno(Integer facultadId, Integer lectivoId, Integer geograficaId, BigDecimal personaId,
 			Integer documentoId) {
 		PendienteInfo info = new PendienteInfo();
-		info.setFacultad(facultadservice.findByFacultadId(facultadId));
-		info.setLectivo(lectivoservice.findByLectivoId(lectivoId));
-		info.setGeografica(geograficaservice.findByGeograficaId(geograficaId));
-		info.setDocumento(documentoservice.findByDocumentoId(documentoId));
-		info.setPersona(personaservice.findByPersonaIdAndDocumentoId(personaId, documentoId));
-		Inscripcion inscripcion = null;
-		info.setInscripcion(
-				inscripcion = inscripcionservice.findByUnique(facultadId, personaId, documentoId, lectivoId));
-		info.setPlan(planservice.findByUnique(inscripcion.getFacultadId(), inscripcion.getPlanId()));
-		info.setCarrera(carreraservice.findByUnique(inscripcion.getFacultadId(), inscripcion.getPlanId(),
-				inscripcion.getCarreraId()));
-		info.setDetalles(inscripciondetalleservice.findAllByPersona(personaId, documentoId, facultadId, lectivoId));
-		info.setMaterias(materiaservice.findAllByPlan(inscripcion.getFacultadId(), inscripcion.getPlanId()));
-		List<MateriaCarreraEntity> materias = null;
-		info.setMateriascarrera(materias = materiacarreraservice.findAllByCarrera(inscripcion.getFacultadId(),
-				inscripcion.getPlanId(), inscripcion.getCarreraId()));
-		info.setMateriascurso(materiacursoservice.findAllByCarrera(inscripcion.getFacultadId(), inscripcion.getPlanId(),
-				inscripcion.getCarreraId()));
-		info.setRegularidades(regularidadservice.findAllByMaterias(personaId, documentoId, inscripcion.getFacultadId(),
-				inscripcion.getPlanId(),
-				materias.stream().map(MateriaCarreraEntity::getMateriaId).collect(Collectors.toList())));
-		info.setInscripciones(inscripcionservice.findAllAnteriores(personaId, documentoId, facultadId, lectivoId));
+		info.setFacultad(load("facultad", () -> facultadservice.findByFacultadId(facultadId), facultadId,
+				personaId, documentoId, null));
+		info.setLectivo(load("lectivo", () -> lectivoservice.findByLectivoId(lectivoId), facultadId, personaId,
+				documentoId, null));
+		info.setGeografica(load("geografica", () -> geograficaservice.findByGeograficaId(geograficaId), facultadId,
+				personaId, documentoId, null));
+		info.setDocumento(load("documento", () -> documentoservice.findByDocumentoId(documentoId), facultadId,
+				personaId, documentoId, null));
+		info.setPersona(load("persona", () -> personaservice.findByPersonaIdAndDocumentoId(personaId, documentoId),
+				facultadId, personaId, documentoId, null));
+
+		Inscripcion inscripcion = load("inscripcion",
+				() -> inscripcionservice.findByUnique(facultadId, personaId, documentoId, lectivoId), facultadId,
+				personaId, documentoId, null);
+		info.setInscripcion(inscripcion);
+		info.setDetalles(load("detalles",
+				() -> inscripciondetalleservice.findAllByPersona(personaId, documentoId, facultadId, lectivoId),
+				facultadId, personaId, documentoId, List.of()));
+		info.setInscripciones(load("inscripciones anteriores",
+				() -> inscripcionservice.findAllAnteriores(personaId, documentoId, facultadId, lectivoId), facultadId,
+				personaId, documentoId, List.of()));
+
+		if (inscripcion == null) {
+			info.setMaterias(List.of());
+			info.setMateriascarrera(List.of());
+			info.setMateriascurso(List.of());
+			info.setRegularidades(List.of());
+			return info;
+		}
+
+		Integer inscripcionFacultadId = inscripcion.getFacultadId();
+		Integer planId = inscripcion.getPlanId();
+		Integer carreraId = inscripcion.getCarreraId();
+		info.setPlan(load("plan", () -> planservice.findByUnique(inscripcionFacultadId, planId), facultadId,
+				personaId, documentoId, null));
+		info.setCarrera(load("carrera", () -> carreraservice.findByUnique(inscripcionFacultadId, planId, carreraId),
+				facultadId, personaId, documentoId, null));
+		info.setMaterias(load("materias", () -> materiaservice.findAllByPlan(inscripcionFacultadId, planId), facultadId,
+				personaId, documentoId, List.of()));
+		List<MateriaCarreraEntity> materiasCarrera = load("materias carrera",
+				() -> materiacarreraservice.findAllByCarrera(inscripcionFacultadId, planId, carreraId), facultadId,
+				personaId, documentoId, List.of());
+		info.setMateriascarrera(materiasCarrera);
+		info.setMateriascurso(load("materias curso",
+				() -> materiacursoservice.findAllByCarrera(inscripcionFacultadId, planId, carreraId), facultadId,
+				personaId, documentoId, List.of()));
+		info.setRegularidades(load("regularidades",
+				() -> regularidadservice.findAllByMaterias(personaId, documentoId, inscripcionFacultadId, planId,
+						materiasCarrera.stream().map(MateriaCarreraEntity::getMateriaId).toList()),
+				facultadId, personaId, documentoId, List.of()));
 		return info;
+	}
+
+	private <T> T load(String section, Supplier<T> supplier, Integer facultadId, BigDecimal personaId,
+			Integer documentoId, T fallback) {
+		try {
+			T value = supplier.get();
+			return value == null ? fallback : value;
+		} catch (RuntimeException exception) {
+			log.warn("No se pudo cargar la sección {} para facultad={}, persona={}, documento={}", section, facultadId,
+					personaId, documentoId, exception);
+			return fallback;
+		}
 	}
 
 }

--- a/src/test/java/um/facultad/rest/service/dto/PendienteInfoServiceTest.java
+++ b/src/test/java/um/facultad/rest/service/dto/PendienteInfoServiceTest.java
@@ -1,0 +1,109 @@
+package um.facultad.rest.service.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import um.facultad.rest.hexagonal.carreras.carrera.application.service.CarreraService;
+import um.facultad.rest.hexagonal.carreras.materia.application.service.MateriaService;
+import um.facultad.rest.hexagonal.carreras.plan.application.service.PlanService;
+import um.facultad.rest.hexagonal.inscripciones.inscripcion.application.service.InscripcionService;
+import um.facultad.rest.hexagonal.inscripciones.inscripcionDetalle.application.service.InscripcionDetalleService;
+import um.facultad.rest.hexagonal.inscripciones.inscripcion.domain.model.Inscripcion;
+import um.facultad.rest.hexagonal.personas.persona.application.service.PersonaService;
+import um.facultad.rest.service.DocumentoService;
+import um.facultad.rest.service.FacultadService;
+import um.facultad.rest.service.GeograficaService;
+import um.facultad.rest.service.LectivoService;
+import um.facultad.rest.service.MateriaCarreraService;
+import um.facultad.rest.service.MateriaCursoService;
+import um.facultad.rest.service.RegularidadService;
+import um.facultad.rest.model.dto.PendienteInfo;
+
+@ExtendWith(MockitoExtension.class)
+class PendienteInfoServiceTest {
+
+    private static final Integer FACULTAD_ID = 1;
+    private static final Integer LECTIVO_ID = 2;
+    private static final Integer GEOGRAFICA_ID = 3;
+    private static final BigDecimal PERSONA_ID = BigDecimal.ONE;
+    private static final Integer DOCUMENTO_ID = 4;
+
+    @Mock
+    private FacultadService facultadservice;
+    @Mock
+    private LectivoService lectivoservice;
+    @Mock
+    private GeograficaService geograficaservice;
+    @Mock
+    private DocumentoService documentoservice;
+    @Mock
+    private PersonaService personaservice;
+    @Mock
+    private InscripcionService inscripcionservice;
+    @Mock
+    private PlanService planservice;
+    @Mock
+    private CarreraService carreraservice;
+    @Mock
+    private InscripcionDetalleService inscripciondetalleservice;
+    @Mock
+    private MateriaService materiaservice;
+    @Mock
+    private MateriaCarreraService materiacarreraservice;
+    @Mock
+    private MateriaCursoService materiacursoservice;
+    @Mock
+    private RegularidadService regularidadservice;
+
+    @InjectMocks
+    private PendienteInfoService service;
+
+    @Test
+    void devuelveRespuestaParcialCuandoFallaUnaCargaBase() {
+        when(facultadservice.findByFacultadId(FACULTAD_ID)).thenThrow(new RuntimeException("facultad no disponible"));
+        when(inscripcionservice.findByUnique(FACULTAD_ID, PERSONA_ID, DOCUMENTO_ID, LECTIVO_ID))
+                .thenThrow(new RuntimeException("inscripcion no disponible"));
+
+        PendienteInfo result = service.findByAlumno(FACULTAD_ID, LECTIVO_ID, GEOGRAFICA_ID, PERSONA_ID,
+                DOCUMENTO_ID);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getFacultad()).isNull();
+        assertThat(result.getInscripcion()).isNull();
+        assertThat(result.getDetalles()).isEmpty();
+        assertThat(result.getMaterias()).isEmpty();
+        assertThat(result.getMateriascarrera()).isEmpty();
+        assertThat(result.getMateriascurso()).isEmpty();
+        assertThat(result.getRegularidades()).isEmpty();
+        assertThat(result.getInscripciones()).isEmpty();
+    }
+
+    @Test
+    void continuaConElRestoCuandoFallaUnaCargaDependiente() {
+        Inscripcion inscripcion = Inscripcion.builder()
+                .facultadId(FACULTAD_ID)
+                .planId(10)
+                .carreraId(20)
+                .build();
+        when(inscripcionservice.findByUnique(FACULTAD_ID, PERSONA_ID, DOCUMENTO_ID, LECTIVO_ID))
+                .thenReturn(inscripcion);
+        when(materiacarreraservice.findAllByCarrera(FACULTAD_ID, 10, 20))
+                .thenThrow(new RuntimeException("materias no disponibles"));
+
+        PendienteInfo result = service.findByAlumno(FACULTAD_ID, LECTIVO_ID, GEOGRAFICA_ID, PERSONA_ID,
+                DOCUMENTO_ID);
+
+        assertThat(result.getInscripcion()).isSameAs(inscripcion);
+        assertThat(result.getMateriascarrera()).isEmpty();
+        assertThat(result.getMateriascurso()).isEmpty();
+        assertThat(result.getRegularidades()).isEmpty();
+    }
+}


### PR DESCRIPTION
Closes #62

## Descripción
Mejora la resiliencia de `PendienteInfoService` para que el endpoint de información del alumno devuelva los datos disponibles aunque falle la carga de una sección. Las colecciones afectadas usan valores vacíos y los errores se registran con contexto. También publica la versión `1.6.4`.

## Cambios Realizados
- [x] Aislar la carga de cada sección mediante fallbacks y logging contextual.
- [x] Evitar cargas dependientes cuando no existe la inscripción y devolver colecciones vacías.
- [x] Agregar pruebas unitarias para fallos en cargas base y dependientes.
- [x] Actualizar la versión a `1.6.4` en `pom.xml`, `README.md` y `CHANGELOG.md`.

## Verificación
`mvn test` completado correctamente: 5 pruebas ejecutadas, 0 fallos y 0 errores.
